### PR TITLE
Saturate IndexOrder Fill Rate

### DIFF
--- a/src/solver/batch_manager.rs
+++ b/src/solver/batch_manager.rs
@@ -678,7 +678,7 @@ impl BatchManager {
             // We're finding lowest fill-rate for this Index Order across all assets, because
             // we cannot fill this Index Order more than least available asset fill-rate.
             fill_rate = fill_rate.map_or(Some(avialable_fill_rate), |x: Amount| {
-                Some(x.min(avialable_fill_rate).min(Amount::ONE))
+                Some(x.min(avialable_fill_rate))
             });
             tracing::info!(
                 "(batch-manager) Fill Basket Asset: {:5} q={:0.5} pos={:0.5} aq={:0.5} cf={:0.5} afr={:0.5}",
@@ -691,7 +691,10 @@ impl BatchManager {
             );
         }
 
-        let fill_rate = fill_rate.expect("Fill-rate must have been known at this stage");
+        // The index-order fill-rate must never exceed 100%
+        let fill_rate = fill_rate
+            .expect("Fill-rate must have been known at this stage")
+            .min(Amount::ONE);
 
         // This is new filled quantity of this batch engagement with Index Order
         let filled_quantity = safe!(fill_rate * engaged_quantity).ok_or_eyre("Math Problem")?;


### PR DESCRIPTION
## Work
- [x] Saturate Index Order fill-rate so that it is never higher than 100%

## About
Batch Manager scans Asset Positions in the batch and using Asset Contribution Fractions pre-assigns them to Index Orders. This pre-assignments are only a computation and not actual assignment of any lots. The purpose of the computation is to find maximum possible fill-rate using the assets filled in the batch following the Index Order contribution to that batch. That maximum possible fill-rate is computed as a minimum of fill-rate for each asset in index so that it never exceeds 100%.