### PR TITLE
Add unix signal processing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ safe-math = { workspace = true }
 symm-core = { workspace = true }
 axum-fix-server = { workspace = true }
 serde = { version = "1.0.219", features = ["derive"] }
-serde_json = "1.0.140"
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }


### PR DESCRIPTION
Removes the timer of 60s and terminates the program gracefully when recieving a SIGINT, SIGTERM or SIGQUIT.

It was necessary to change main signature from

async fn main()

to

async fn main() -> Result<(), Box<dyn std::error::Error>>