### PR TITLE
Inject tracing span with baggage before event handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1657,6 +1657,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-with-baggage"
+version = "0.1.0"
+dependencies = [
+ "eyre",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2520,6 +2529,7 @@ dependencies = [
  "chrono",
  "clap",
  "crossbeam",
+ "derive-with-baggage",
  "derive_builder",
  "eyre",
  "futures-util",
@@ -4277,6 +4287,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "crossbeam",
+ "derive-with-baggage",
  "eyre",
  "futures-util",
  "intrusive-collections",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "libs/market-data",
     "libs/symm-core",
     "examples",
+    "proc-macros/derive-with-baggage",
     "proc-macros/safe-math",
 ]
 
@@ -32,6 +33,7 @@ chrono = { workspace = true }
 clap = { workspace = true }
 crossbeam = { workspace = true }
 derive_builder = { workspace = true }
+derive-with-baggage = { workspace = true }
 eyre = { workspace = true }
 futures-util = { workspace = true }
 intrusive-collections = { workspace = true }
@@ -75,6 +77,7 @@ chrono = { version = "0.4.41", features = ["serde"] }
 clap = { version = "4.5", features = ["derive"] }
 crossbeam = "0.8.4"
 derive_builder = "^0.10"
+derive-with-baggage = { path = "./proc-macros/derive-with-baggage" }
 eyre = "0.6.12"
 futures-util = "0.3.31"
 index-maker = { path = "." }

--- a/libs/symm-core/Cargo.toml
+++ b/libs/symm-core/Cargo.toml
@@ -9,6 +9,7 @@ alloy = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 crossbeam = { workspace = true }
+derive-with-baggage = { workspace = true }
 eyre = { workspace = true }
 futures-util = { workspace = true }
 intrusive-collections = { workspace = true }

--- a/libs/symm-core/src/order_sender/order_tracker.rs
+++ b/libs/symm-core/src/order_sender/order_tracker.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 use eyre::{eyre, OptionExt, Result};
-use opentelemetry::propagation::Injector;
 use safe_math::safe;
 use std::collections::{hash_map::Entry, HashMap};
 
@@ -10,7 +9,11 @@ use crossbeam::atomic::AtomicCell;
 use parking_lot::RwLock;
 
 use crate::core::functional::{IntoObservableSingle, PublishSingle};
-use crate::core::telemetry::WithBaggage;
+
+use crate::core::telemetry::{TracingData, WithBaggage};
+use derive_with_baggage::WithBaggage;
+use opentelemetry::propagation::Injector;
+
 use crate::core::{
     bits::{Amount, BatchOrderId, OrderId, Side, SingleOrder, Symbol},
     decimal_ext::DecimalExt,
@@ -23,12 +26,18 @@ use crate::{
 };
 
 /// track orders that we sent to
-#[derive(Debug)]
+#[derive(Debug, WithBaggage)]
 pub enum OrderTrackerNotification {
     Fill {
+        #[baggage]
         order_id: OrderId,
+
+        #[baggage]
         batch_order_id: BatchOrderId,
+
+        #[baggage]
         lot_id: LotId,
+
         symbol: Symbol,
         side: Side,
         price_filled: Amount,
@@ -40,8 +49,12 @@ pub enum OrderTrackerNotification {
         fill_timestamp: DateTime<Utc>,
     },
     Cancel {
+        #[baggage]
         order_id: OrderId,
+
+        #[baggage]
         batch_order_id: BatchOrderId,
+
         symbol: Symbol,
         side: Side,
         quantity_cancelled: Amount,
@@ -50,31 +63,6 @@ pub enum OrderTrackerNotification {
         is_cancelled: bool,
         cancel_timestamp: DateTime<Utc>,
     },
-}
-
-impl WithBaggage for OrderTrackerNotification {
-    fn inject_baggage(&self, tracing_data: &mut crate::core::telemetry::TracingData) {
-        match self {
-            OrderTrackerNotification::Fill {
-                order_id,
-                batch_order_id,
-                lot_id,
-                ..
-            } => {
-                tracing_data.set("order_id", order_id.to_string());
-                tracing_data.set("batch_order_id", batch_order_id.to_string());
-                tracing_data.set("lot_id", lot_id.to_string());
-            }
-            OrderTrackerNotification::Cancel {
-                order_id,
-                batch_order_id,
-                ..
-            } => {
-                tracing_data.set("order_id", order_id.to_string());
-                tracing_data.set("batch_order_id", batch_order_id.to_string());
-            }
-        }
-    }
 }
 
 #[derive(Clone, Copy)]

--- a/libs/symm-core/src/tracing/otlp_log.rs
+++ b/libs/symm-core/src/tracing/otlp_log.rs
@@ -29,7 +29,8 @@ pub fn create_otlp_log_layer(url: String) -> eyre::Result<SdkLoggerProvider> {
         .with_resource(
             Resource::builder()
                 .with_service_name("index-maker")
-                .with_attribute(KeyValue::new("environment", "development"))
+                .with_attribute(KeyValue::new("service.version", "1.0.0"))
+                .with_attribute(KeyValue::new("deployment.environment", "production"))
                 .build(),
         )
         .build();

--- a/libs/symm-core/src/tracing/otlp_tracing.rs
+++ b/libs/symm-core/src/tracing/otlp_tracing.rs
@@ -31,7 +31,8 @@ pub fn create_otlp_trace_layer(url: String) -> eyre::Result<SdkTracer> {
         .with_resource(
             Resource::builder()
                 .with_service_name("index-maker")
-                .with_attribute(KeyValue::new("environment", "development"))
+                .with_attribute(KeyValue::new("service.version", "1.0.0"))
+                .with_attribute(KeyValue::new("deployment.environment", "production"))
                 .build(),
         )
         .build();

--- a/proc-macros/derive-with-baggage/Cargo.toml
+++ b/proc-macros/derive-with-baggage/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "derive-with-baggage"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = { workspace = true }
+syn = { workspace = true }
+eyre = { workspace = true }

--- a/proc-macros/derive-with-baggage/src/lib.rs
+++ b/proc-macros/derive-with-baggage/src/lib.rs
@@ -1,0 +1,88 @@
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, Data, DeriveInput, Fields};
+
+/// Main entry point for the `#[derive(WithBaggage)]` procedural macro.
+#[proc_macro_derive(WithBaggage, attributes(baggage))]
+pub fn derive_with_baggage(input: TokenStream) -> TokenStream {
+    // Parse the input tokens into a syntax tree.
+    let input = parse_macro_input!(input as DeriveInput);
+
+    // Extract the name of the type for which we are deriving the trait.
+    let name = &input.ident;
+
+    // Get the generics from the input type, so we can apply them to the impl block.
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    // Generate the implementation of the `WithBaggage` trait.
+    let expanded = match &input.data {
+        Data::Enum(data_enum) => {
+            
+            // Iterate over each variant of the enum.
+            let match_arms = data_enum.variants.iter().map(|variant| {
+                let variant_name = &variant.ident;
+                let mut field_injectors = Vec::new();
+                let mut field_names = Vec::new();
+
+                match &variant.fields {
+
+                    // We only support named fields
+                    Fields::Named(fields) => {
+                        for field in &fields.named {
+                            
+                            // Get field name and its attributes
+                            let field_name = field.ident.as_ref().unwrap();
+                            let has_baggage_attr = field.attrs.iter().any(|attr| attr.path().is_ident("baggage"));
+
+                            // If there is #[baggage] attribute on the field
+                            if has_baggage_attr {
+                                // then destructure that field
+                                field_names.push(quote! { #field_name });
+
+                                // and implement injector taking name of tha field and the value of that field
+                                field_injectors.push(quote! {
+                                    tracing_data.set(stringify!(#field_name), #field_name.to_string());
+                                });
+
+                            } else {
+                                // Otherwise we still need to destructure that field, but we won't use it
+                                field_names.push(quote! { #field_name: _ });
+                            }
+                        }
+
+                        // Construct the pattern for named fields: `Variant { field1, field2: _, ... }`
+                        let fields_pattern = quote! { { #(#field_names),* } };
+                        quote! {
+                            Self::#variant_name #fields_pattern => {
+                                #(#field_injectors)*
+                            }
+                        }
+                    }
+                    _ => { quote! { _ => {} } }
+                }
+            });
+
+            // The generated `impl` block for the enum.
+            quote! {
+                impl #impl_generics WithBaggage for #name #ty_generics #where_clause {
+                    fn inject_baggage(&self, tracing_data: &mut TracingData) {
+                        match self {
+                            #(#match_arms),*
+                        }
+                    }
+                }
+            }
+        }
+        Data::Struct(_) => {
+            panic!("WithBaggage derive macro only supports enums at the moment.");
+        }
+        Data::Union(_) => {
+            panic!("WithBaggage derive macro does not support unions.");
+        }
+    };
+
+    // Hand the generated code back to the compiler.
+    expanded.into()
+}

--- a/src/blockchain/chain_connector.rs
+++ b/src/blockchain/chain_connector.rs
@@ -2,6 +2,10 @@ use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 
+use symm_core::core::telemetry::{TracingData, WithBaggage};
+use derive_with_baggage::WithBaggage;
+use opentelemetry::propagation::Injector;
+
 use symm_core::core::{
     bits::{Address, Amount, Symbol},
     functional::IntoObservableSingleVTable,
@@ -12,17 +16,26 @@ use crate::index::basket::{Basket, BasketDefinition};
 /// call blockchain methods, receive blockchain events
 
 /// On-chain event
+#[derive(WithBaggage)]
 pub enum ChainNotification {
     CuratorWeightsSet(Symbol, BasketDefinition), // ...more
     Deposit {
+        #[baggage]
         chain_id: u32,
+        
+        #[baggage]
         address: Address,
+
         amount: Amount,
         timestamp: DateTime<Utc>,
     },
     WithdrawalRequest {
+        #[baggage]
         chain_id: u32,
+
+        #[baggage]
         address: Address,
+
         amount: Amount,
         timestamp: DateTime<Utc>,
     },

--- a/src/collateral/collateral_router.rs
+++ b/src/collateral/collateral_router.rs
@@ -8,18 +8,29 @@ use itertools::Itertools;
 
 use eyre::{eyre, OptionExt, Result};
 
+use symm_core::core::telemetry::{TracingData, WithBaggage, WithTracingContext};
+use derive_with_baggage::WithBaggage;
+use opentelemetry::propagation::Injector;
+
+
 use serde::Serialize;
 use symm_core::core::{
     bits::{Address, Amount, ClientOrderId, Side, Symbol},
     functional::{IntoObservableSingle, IntoObservableSingleVTable, PublishSingle, SingleObserver},
 };
 
-#[derive(Serialize)]
+#[derive(WithBaggage)]
 pub enum CollateralTransferEvent {
     TransferComplete {
+        #[baggage]
         chain_id: u32,
+
+        #[baggage]
         address: Address,
+
+        #[baggage]
         client_order_id: ClientOrderId,
+
         timestamp: DateTime<Utc>,
         transfer_from: Symbol,
         transfer_to: Symbol,
@@ -28,12 +39,18 @@ pub enum CollateralTransferEvent {
     },
 }
 
-#[derive(Serialize)]
+#[derive(WithBaggage)]
 pub enum CollateralRouterEvent {
     HopComplete {
+        #[baggage]
         chain_id: u32,
+        
+        #[baggage]
         address: Address,
+        
+        #[baggage]
         client_order_id: ClientOrderId,
+
         timestamp: DateTime<Utc>,
         source: Symbol,
         destination: Symbol,

--- a/src/index/basket_manager.rs
+++ b/src/index/basket_manager.rs
@@ -6,8 +6,6 @@ use symm_core::core::{
     functional::{IntoObservableSingle, PublishSingle, SingleObserver},
 };
 
-use crate::index::basket;
-
 use super::basket::{Basket, BasketDefinition};
 
 pub enum BasketNotification {

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -4,6 +4,9 @@ use chrono::{DateTime, Utc};
 use serde::Serialize;
 use thiserror::Error;
 
+use symm_core::core::telemetry::{TracingData, WithBaggage};
+use derive_with_baggage::WithBaggage;
+use opentelemetry::propagation::Injector;
 
 use symm_core::core::{
     bits::{Address, Amount, ClientOrderId, ClientQuoteId, Side, Symbol},
@@ -12,38 +15,62 @@ use symm_core::core::{
 
 use crate::solver::mint_invoice::MintInvoice;
 
-#[derive(Serialize)]
+#[derive(Serialize, WithBaggage)]
 pub enum ServerEvent {
     NewIndexOrder {
+        #[baggage]
         chain_id: u32,
+        
+        #[baggage]
         address: Address,
+        
+        #[baggage]
         client_order_id: ClientOrderId,
+
         symbol: Symbol,
         side: Side,
         collateral_amount: Amount,
         timestamp: DateTime<Utc>,
     },
     CancelIndexOrder {
+        #[baggage]
         chain_id: u32,
+        
+        #[baggage]
         address: Address,
+        
+        #[baggage]
         client_order_id: ClientOrderId,
+
         symbol: Symbol,
         collateral_amount: Amount,
         timestamp: DateTime<Utc>,
     },
     NewQuoteRequest {
+        #[baggage]
         chain_id: u32,
+        
+        #[baggage]
         address: Address,
+        
+        #[baggage]
         client_quote_id: ClientQuoteId,
+
         symbol: Symbol,
         side: Side,
         collateral_amount: Amount,
         timestamp: DateTime<Utc>,
     },
     CancelQuoteRequest {
+        #[baggage]
         chain_id: u32,
+        
+        #[baggage]
         address: Address,
+        
+        #[baggage]
         client_quote_id: ClientQuoteId,
+
         symbol: Symbol,
         timestamp: DateTime<Utc>,
     },

--- a/src/solver/index_quote_manager.rs
+++ b/src/solver/index_quote_manager.rs
@@ -7,7 +7,9 @@ use chrono::{DateTime, Utc};
 use eyre::{eyre, Result};
 use parking_lot::RwLock;
 
-use serde::Serialize;
+use derive_with_baggage::WithBaggage;
+use opentelemetry::propagation::Injector;
+use symm_core::core::telemetry::{TracingData, WithBaggage};
 
 use crate::{
     server::server::{
@@ -23,21 +25,33 @@ use symm_core::core::{
 
 use super::solver::SolveQuotesResult;
 
-#[derive(Serialize)]
+#[derive(WithBaggage)]
 pub enum QuoteRequestEvent {
     NewQuoteRequest {
+        #[baggage]
         chain_id: u32,
+
+        #[baggage]
         address: Address,
+
+        #[baggage]
         client_quote_id: ClientQuoteId,
+
         symbol: Symbol,
         side: Side,
         collateral_amount: Amount,
         timestamp: DateTime<Utc>,
     },
     CancelQuoteRequest {
+        #[baggage]
         chain_id: u32,
+        
+        #[baggage]
         address: Address,
+        
+        #[baggage]
         client_quote_id: ClientQuoteId,
+
         timestamp: DateTime<Utc>,
     },
 }


### PR DESCRIPTION
## Work
- [x] Tracing span is injected into each event handling
- [x] Baggage is injected into dedicated tracing span

## About
OTel Baggage is a piece of data that is travelling with OTel contexts, however it is not something that is exported to OTLP collector and thus it's also not visible in Kibana. This change extracts baggage before handiling of each event, and injects a parent tracing span with that baggage data, so that the handling of that event happens within that span, which means that all information logged will be traced within that span allowing for analysis in Kibana.