### PR TITLE
Quote lifecycle tracking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ build: \
 	build_docker_image
 
 prepare: \
+	clean \
 	save_docker_image \
 	docker_compose_yaml \
 	otel_collector_config_yaml \
@@ -113,8 +114,8 @@ build_service_sh: deploy_dir
 	cat $(TEMPLATES_DIR)/build-service.sh.template \
 	| sed -e "s/<IMAGE_VERSION>/$(IMAGE_VERSION)/g" \
 	| sed -e "s/<TAR_ARCHIVE_NAME>/$(TAR_ARCHIVE_NAME)/g" \
-	> $(DEPLOY_DIR)/build-service.sh
-	chmod a+x $(DEPLOY_DIR)/build-service.sh
+	> $(DEPLOY_DIR)/build-service-$(IMAGE_VERSION).sh
+	chmod a+x $(DEPLOY_DIR)/build-service-$(IMAGE_VERSION).sh
 
 stop_service_sh: deploy_dir
 	cat $(TEMPLATES_DIR)/stop-service.sh.template \
@@ -129,7 +130,7 @@ copy_to_remote: check_ssh_env
 	scp $(DEPLOY_DIR)/* $(SSH_USER)@index_maker:/home/$(SSH_USER)/$(REMOTE_DIR)
 
 run_build_service: check_ssh_env
-	ssh $(SSH_USER)@index_maker "cd $(REMOTE_DIR) && ./build-service.sh"
+	ssh $(SSH_USER)@index_maker "cd $(REMOTE_DIR) && ./build-service-$(IMAGE_VERSION).sh"
 
 run_stop_service: check_ssh_env
 	ssh $(SSH_USER)@index_maker "cd $(REMOTE_DIR) && ./stop-service.sh"

--- a/deploy_templates/build-service.sh.template
+++ b/deploy_templates/build-service.sh.template
@@ -6,7 +6,7 @@ if [ -f ./stop-service.sh ]; then
 fi
 
 # Save *current* version of stop service script
-mv stop-service-<IMAGE_VERSION>.sh stop-service.sh
+cp stop-service-<IMAGE_VERSION>.sh stop-service.sh
 
 docker load -i <TAR_ARCHIVE_NAME> && \
 docker-compose -f docker-compose.prod-<IMAGE_VERSION>.yaml up -d --build

--- a/deploy_templates/docker-compose.prod.yaml.template
+++ b/deploy_templates/docker-compose.prod.yaml.template
@@ -7,7 +7,12 @@ services:
     ports:
        - "3000:3000"
 
-    command: ["./index-maker", "-b", "0.0.0.0:3000", "-c", "configs", "--otlp-trace-url", "http://otel-collector:4318/v1/traces", "quote-server"]
+    command: ["./index-maker", 
+              "-b", "0.0.0.0:3000",
+              "-c", "configs", 
+              "--otlp-trace-url", "http://otel-collector:4318/v1/traces", 
+              "--otlp-log-url", "http://otel-collector:4318/v1/logs", 
+              "quote-server"]
 
     environment:
       RUST_LOG: info,binance_sdk=off


### PR DESCRIPTION
- [x] Ensure Quotes can be tracked in Elastic / Kibana

We send lots of data to Elastic, but we need to make sure that we can use that data. When user sends request, in our example Quote Request, we want to see what happened within the whole flow thourgh-out the system from when we recieved request, through how we computed values, till we sent response. 

We use `trace_id` and `links.trace_id`.

In order to investigate single quote, one needs to first query Elastic for `client_quote_id : "<put quote id here>"` and then extract `trace_id`_s_ from the results, and add those into query as `or trace_id : "<put trace id>" or trace_id : ...` and as `links.trace_id : "<put trace_id here>"`. The `links.trace_id` allows us to link independent traces into one log. 