### PR TITLE
Make logs traceable in Kibana 

### DIFF
--- a/deploy_templates/docker-compose.prod.yaml.template
+++ b/deploy_templates/docker-compose.prod.yaml.template
@@ -12,11 +12,12 @@ services:
               "-c", "configs", 
               "--otlp-trace-url", "http://otel-collector:4318/v1/traces", 
               "--otlp-log-url", "http://otel-collector:4318/v1/logs", 
-              "fix-server",
-              "20"]
+              "--batch-size", "4",
+              "--simulate-sender",
+              "fix-server", "1000000"]
 
     environment:
-      RUST_LOG: info,binance_sdk=off
+      RUST_LOG: debug,binance_sdk=off,hyper=off
     
     depends_on:
       otel-collector:

--- a/deploy_templates/docker-compose.prod.yaml.template
+++ b/deploy_templates/docker-compose.prod.yaml.template
@@ -12,7 +12,8 @@ services:
               "-c", "configs", 
               "--otlp-trace-url", "http://otel-collector:4318/v1/traces", 
               "--otlp-log-url", "http://otel-collector:4318/v1/logs", 
-              "quote-server"]
+              "fix-server",
+              "20"]
 
     environment:
       RUST_LOG: info,binance_sdk=off

--- a/deploy_templates/otel-collector-config.prod.yaml.template
+++ b/deploy_templates/otel-collector-config.prod.yaml.template
@@ -6,8 +6,8 @@ receivers:
 
 processors:
   batch:
-    send_batch_size: 100
-    timeout: 10s
+    send_batch_size: 4
+    timeout: 1s
 
 exporters:
   otlp/elastic:
@@ -16,18 +16,20 @@ exporters:
       Authorization: "<ELASTIC_API_KEY>"
     tls:
       insecure: false
+  debug:
+    verbosity: detailed
 
 service:
   pipelines:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [otlp/elastic]
+      exporters: [otlp/elastic,debug]
 
     logs:
       receivers: [otlp]
       processors: [batch]
-      exporters: [otlp/elastic]
+      exporters: [otlp/elastic,debug]
 
     metrics:
       receivers: [otlp]

--- a/examples/fix_server/responses.rs
+++ b/examples/fix_server/responses.rs
@@ -42,19 +42,13 @@ impl Response {
         }
     }
 
-    pub fn create_ack(
-        user_id: &(u32, Address),
-        session_id: &SessionId,
-        seq_num: u32,
-    ) -> Self {
+    pub fn create_ack(user_id: &(u32, Address), session_id: &SessionId, seq_num: u32) -> Self {
         Response {
             session_id: session_id.clone(),
             standard_header: FixHeader::new("ACK".to_string()),
             chain_id: user_id.0,
             address: user_id.1,
-            body: Body::ACKBody {
-                RefSeqNum: seq_num,
-            },
+            body: Body::ACKBody { RefSeqNum: seq_num },
             standard_trailer: FixTrailer::new(),
         }
     }
@@ -96,12 +90,8 @@ impl AxumServerResponse for Response {
     ) -> Self {
         Response::create_nak(user_id, session_id, ref_seq_num, error_msg)
     }
-    
-    fn format_ack(
-        user_id: &(u32, Address),
-        session_id: &SessionId,
-        ref_seq_num: u32,
-    ) -> Self {
+
+    fn format_ack(user_id: &(u32, Address), session_id: &SessionId, ref_seq_num: u32) -> Self {
         Response::create_ack(user_id, session_id, ref_seq_num)
     }
 }

--- a/libs/axum-fix-server/src/messages.rs
+++ b/libs/axum-fix-server/src/messages.rs
@@ -43,9 +43,5 @@ pub trait ServerResponse {
         ref_seq_num: u32,
     ) -> Self;
 
-    fn format_ack(
-        user_id: &(u32, Address),
-        session_id: &SessionId,
-        ref_seq_num: u32,
-    ) -> Self;
+    fn format_ack(user_id: &(u32, Address), session_id: &SessionId, ref_seq_num: u32) -> Self;
 }

--- a/libs/axum-fix-server/src/plugins/user_plugin.rs
+++ b/libs/axum-fix-server/src/plugins/user_plugin.rs
@@ -37,19 +37,18 @@ impl UserPlugin {
         }
     }
 
-
     pub fn remove_session(&self, session_id: &SessionId) {
         let user_id_option = {
             let read_lock = self.users_sessions.read().unwrap();
             read_lock.iter().find_map(|(key, values)| {
                 if values.contains(session_id) {
-                    Some(key.clone()) 
+                    Some(key.clone())
                 } else {
                     None
                 }
             })
         };
-        
+
         if let Some(user_id) = user_id_option {
             self.remove_user_session(&user_id, session_id);
         }

--- a/libs/binance-order-sending/src/binance_order_sending.rs
+++ b/libs/binance-order-sending/src/binance_order_sending.rs
@@ -5,7 +5,7 @@ use parking_lot::RwLock as AtomicLock;
 use symm_core::{
     core::{
         bits::{SingleOrder, Symbol},
-        functional::{IntoObservableSingleArc, SingleObserver},
+        functional::{IntoObservableSingleArc, IntoObservableSingleVTable, NotificationHandlerOnce, SingleObserver},
     },
     order_sender::order_connector::{OrderConnector, OrderConnectorNotification, SessionId},
 };
@@ -91,5 +91,14 @@ impl IntoObservableSingleArc<OrderConnectorNotification> for BinanceOrderSending
         &mut self,
     ) -> &Arc<AtomicLock<SingleObserver<OrderConnectorNotification>>> {
         &self.observer
+    }
+}
+
+impl IntoObservableSingleVTable<OrderConnectorNotification> for BinanceOrderSending {
+    fn set_observer(
+        &mut self,
+        observer: Box<dyn NotificationHandlerOnce<OrderConnectorNotification>>,
+    ) {
+        self.observer.write().set_observer(observer);
     }
 }

--- a/libs/symm-core/src/core/logging.rs
+++ b/libs/symm-core/src/core/logging.rs
@@ -133,7 +133,7 @@ macro_rules! init_log {
             None,
             false,
             None,
-            None
+            None,
         );
     };
     ($log_path:expr) => {
@@ -142,7 +142,7 @@ macro_rules! init_log {
             $log_path,
             false,
             None,
-            None
+            None,
         );
     };
     ($disable_terminal_log:expr) => {
@@ -151,7 +151,7 @@ macro_rules! init_log {
             None,
             $disable_terminal_log,
             None,
-            None
+            None,
         );
     };
     ($log_path:expr, $disable_terminal_log:expr) => {
@@ -160,7 +160,7 @@ macro_rules! init_log {
             $log_path,
             $disable_terminal_log,
             None,
-            None
+            None,
         );
     };
     ($log_path:expr, $disable_terminal_log:expr, $otlp_trace_url:expr, $otlp_log_url:expr) => {

--- a/libs/symm-core/src/core/logging.rs
+++ b/libs/symm-core/src/core/logging.rs
@@ -4,7 +4,7 @@ use std::{
 };
 use tracing_appender::rolling::{self, Builder};
 use tracing_subscriber::{
-    fmt::Layer, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Registry,
+    fmt::Layer, layer::SubscriberExt, util::SubscriberInitExt
 };
 
 use crate::tracing::{otlp_log::create_otlp_log_layer, otlp_tracing::create_otlp_trace_layer};
@@ -16,8 +16,9 @@ pub fn log_init(
     filter: String,
     log_path: Option<String>,
     disable_terminal_log: bool,
-    otlp_trace_url: Option<String>,
-    otlp_log_url: Option<String>,
+    otlp_trace_url: Option<Option<String>>,
+    otlp_log_url: Option<Option<String>>,
+    batch_size: Option<usize>,
 ) {
     INIT_LOG.call_once(|| {
         // Set up the terminal output layer
@@ -65,7 +66,7 @@ pub fn log_init(
 
         let otlp_trace_layer = if let Some(url) = otlp_trace_url {
             let tracer =
-                create_otlp_trace_layer(url).expect("Failed to create Open-Telemetry trace layer");
+                create_otlp_trace_layer(url, batch_size).expect("Failed to create Open-Telemetry trace layer");
             let telemetry_trace_layer = tracing_opentelemetry::layer().with_tracer(tracer);
             Some(telemetry_trace_layer)
         } else {
@@ -74,7 +75,7 @@ pub fn log_init(
 
         let otlp_log_layer = if let Some(url) = otlp_log_url {
             let logger_provider =
-                create_otlp_log_layer(url).expect("Failed to create Open-Telemetry log layer");
+                create_otlp_log_layer(url, batch_size).expect("Failed to create Open-Telemetry log layer");
             let telemetry_log_layer =
                 opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge::new(
                     &logger_provider,
@@ -134,42 +135,7 @@ macro_rules! init_log {
             false,
             None,
             None,
-        );
-    };
-    ($log_path:expr) => {
-        log_init(
-            format!("{}=info", env!("CARGO_CRATE_NAME")),
-            $log_path,
-            false,
             None,
-            None,
-        );
-    };
-    ($disable_terminal_log:expr) => {
-        log_init(
-            format!("{}=info", env!("CARGO_CRATE_NAME")),
-            None,
-            $disable_terminal_log,
-            None,
-            None,
-        );
-    };
-    ($log_path:expr, $disable_terminal_log:expr) => {
-        log_init(
-            format!("{}=info", env!("CARGO_CRATE_NAME")),
-            $log_path,
-            $disable_terminal_log,
-            None,
-            None,
-        );
-    };
-    ($log_path:expr, $disable_terminal_log:expr, $otlp_trace_url:expr, $otlp_log_url:expr) => {
-        log_init(
-            format!("{}=info", env!("CARGO_CRATE_NAME")),
-            $log_path,
-            $disable_terminal_log,
-            $otlp_trace_url,
-            $otlp_log_url,
         );
     };
 }

--- a/libs/symm-core/src/lib.rs
+++ b/libs/symm-core/src/lib.rs
@@ -35,9 +35,8 @@ pub mod order_sender {
 }
 
 pub mod tracing {
-    pub mod otlp_tracing;
-    pub mod otlp_log;
     pub mod defer_log;
     pub mod defer_span;
+    pub mod otlp_log;
+    pub mod otlp_tracing;
 }
-

--- a/libs/symm-core/src/order_sender/inventory_manager.rs
+++ b/libs/symm-core/src/order_sender/inventory_manager.rs
@@ -322,7 +322,6 @@ impl InventoryManager {
 
     /// receive new order requests from Solver
     pub fn new_order_batch(&self, batch_order: Arc<BatchOrder>) -> Result<()> {
-        tracing::debug!("New order batch: {}", batch_order.batch_order_id);
         // Start writing to Order Tracker
         let mut guard = self.order_tracker.write();
         // Send all orders out
@@ -346,7 +345,6 @@ impl InventoryManager {
                     )
                 })?;
         }
-        tracing::debug!("No more asset orders");
         // All orders out
         Ok(())
     }

--- a/libs/symm-core/src/order_sender/inventory_manager.rs
+++ b/libs/symm-core/src/order_sender/inventory_manager.rs
@@ -48,19 +48,19 @@ pub enum InventoryEvent {
     CloseLot {
         #[baggage]
         original_order_id: OrderId,
-        
+
         #[baggage]
         original_batch_order_id: BatchOrderId,
-        
+
         #[baggage]
         original_lot_id: LotId,
-        
+
         #[baggage]
         closing_order_id: OrderId,
-        
+
         #[baggage]
         closing_batch_order_id: BatchOrderId,
-        
+
         #[baggage]
         closing_lot_id: LotId,
 
@@ -80,7 +80,7 @@ pub enum InventoryEvent {
     Cancel {
         #[baggage]
         order_id: OrderId,
-        
+
         #[baggage]
         batch_order_id: BatchOrderId,
 

--- a/libs/symm-core/src/order_sender/order_tracker.rs
+++ b/libs/symm-core/src/order_sender/order_tracker.rs
@@ -131,12 +131,12 @@ impl OrderTracker {
                 match order_entry.get_status() {
                     OrderStatus::Sent { order_quantity } => {
                         tracing::info!(
-                            "Order Status {}: Sent({} @ {}) => Live({} @ {})",
-                            order_id,
-                            order_quantity,
-                            order_entry.order.price,
-                            quantity,
-                            price
+                            %order_id,
+                            %order_quantity,
+                            order_price = %order_entry.order.price,
+                            %quantity,
+                            %price,
+                            "Order Status Sent => Live",
                         );
                         order_entry.set_status(OrderStatus::Live {
                             quantity_remaining: quantity,
@@ -224,9 +224,10 @@ impl OrderTracker {
                 // account status then new_order() could chose which session to
                 // send order.
             } => {
-                tracing::debug!("(order-tracker) Session connected: {}", session_id);
+                tracing::info!(%session_id, %timestamp, "Session connected");
+
                 if let Some(prev_sid) = self.session.replace(session_id) {
-                    tracing::warn!("(order-tracker) Dropping previous session: {}", prev_sid);
+                    tracing::warn!(%prev_sid, "Dropping previous session");
                 }
                 Ok(())
             }
@@ -235,9 +236,10 @@ impl OrderTracker {
                 reason,
                 timestamp,
             } => {
-                tracing::debug!(
-                    "(order-tracker) Session diconnected: {}, Reason: {}",
-                    session_id,
+                tracing::info!(
+                    %session_id,
+                    %timestamp,
+                    "Session diconnected: {}",
                     reason
                 );
                 self.session = None;
@@ -252,7 +254,9 @@ impl OrderTracker {
                 reason,
                 timestamp,
             } => {
-                tracing::debug!("Order {} was rejected: {}", order_id, reason);
+                tracing::warn!(%order_id,%symbol, ?side, %price, %quantity, %reason, %timestamp,
+                    "Order was rejected: {}", reason);
+
                 match self.update_order_status(order_id.clone(), quantity, true) {
                     Ok((order_entry, quantity_remaining, was_live, is_cancelled)) => {
                         // Notify about fills sending notification to subscriber (-> Inventory Manager)
@@ -352,11 +356,11 @@ impl OrderTracker {
 
     /// Receive new order requests from InventoryManager
     pub fn new_order(&mut self, order: Arc<SingleOrder>) -> Result<()> {
-        tracing::debug!("NewOrder: {}", order.order_id);
         let session_id = self
             .session
             .clone()
             .ok_or_eyre("No connected session available")?;
+
         match self.orders.entry(order.order_id.clone()) {
             Entry::Occupied(_) => Err(eyre!("Order already sent with ID {}", order.order_id)),
             Entry::Vacant(entry) => {

--- a/libs/symm-core/src/order_sender/order_tracker.rs
+++ b/libs/symm-core/src/order_sender/order_tracker.rs
@@ -132,6 +132,8 @@ impl OrderTracker {
                     OrderStatus::Sent { order_quantity } => {
                         tracing::info!(
                             %order_id,
+                            asset_symbol = %order_entry.order.symbol,
+                            side = ?order_entry.order.side,
                             %order_quantity,
                             order_price = %order_entry.order.price,
                             %quantity,

--- a/libs/symm-core/src/tracing/otlp_log.rs
+++ b/libs/symm-core/src/tracing/otlp_log.rs
@@ -19,7 +19,7 @@ pub fn create_otlp_log_layer(url: String) -> eyre::Result<SdkLoggerProvider> {
         .with_timeout(Duration::from_secs(3))
         .build()?;
 
-    let mut log_processor = DeferLogProcessor::new();
+    let mut log_processor = DeferLogProcessor::new(512);
     log_processor
         .start(otlp_log_exporter)
         .expect("Failed to start defer log processor");

--- a/libs/symm-core/src/tracing/otlp_log.rs
+++ b/libs/symm-core/src/tracing/otlp_log.rs
@@ -7,19 +7,19 @@ use opentelemetry_sdk::Resource;
 
 use crate::tracing::defer_log::DeferLogProcessor;
 
-pub fn create_otlp_log_layer(url: String) -> eyre::Result<SdkLoggerProvider> {
-    // --- OpenTelemetry Logs Setup (NEW) ---
+const DEFAULT_OTLP_LOGS_URL: &str = "http://localhost:4318/v1/logs";
+
+pub fn create_otlp_log_layer(
+    url: Option<String>,
+    batch_size: Option<usize>,
+) -> eyre::Result<SdkLoggerProvider> {
     let otlp_log_exporter = opentelemetry_otlp::LogExporter::builder()
         .with_http()
-        .with_endpoint(if url == "default" {
-            "http://localhost:4318/v1/logs"
-        } else {
-            &url
-        })
+        .with_endpoint(url.unwrap_or(DEFAULT_OTLP_LOGS_URL.into()))
         .with_timeout(Duration::from_secs(3))
         .build()?;
 
-    let mut log_processor = DeferLogProcessor::new(512);
+    let mut log_processor = DeferLogProcessor::new(batch_size.unwrap_or(512));
     log_processor
         .start(otlp_log_exporter)
         .expect("Failed to start defer log processor");

--- a/libs/symm-core/src/tracing/otlp_tracing.rs
+++ b/libs/symm-core/src/tracing/otlp_tracing.rs
@@ -20,7 +20,7 @@ pub fn create_otlp_trace_layer(url: String) -> eyre::Result<SdkTracer> {
         .with_timeout(Duration::from_secs(3))
         .build()?;
 
-    let mut span_processor = DeferSpanProcessor::new();
+    let mut span_processor = DeferSpanProcessor::new(512);
     span_processor
         .start(otlp_trace_exporter)
         .expect("Failed to start defer span processor");

--- a/libs/symm-core/src/tracing/otlp_tracing.rs
+++ b/libs/symm-core/src/tracing/otlp_tracing.rs
@@ -8,19 +8,19 @@ use opentelemetry_sdk::Resource;
 
 use crate::tracing::defer_span::DeferSpanProcessor;
 
-pub fn create_otlp_trace_layer(url: String) -> eyre::Result<SdkTracer> {
-    // --- OpenTelemetry Traces Setup (Existing) ---
+const DEFAULT_OTLP_TRACES_URL: &str = "http://localhost:4318/v1/traces";
+
+pub fn create_otlp_trace_layer(
+    url: Option<String>,
+    batch_size: Option<usize>,
+) -> eyre::Result<SdkTracer> {
     let otlp_trace_exporter = opentelemetry_otlp::SpanExporter::builder()
         .with_http()
-        .with_endpoint(if url == "default" {
-            "http://localhost:4318/v1/traces"
-        } else {
-            &url
-        })
+        .with_endpoint(url.unwrap_or(DEFAULT_OTLP_TRACES_URL.into()))
         .with_timeout(Duration::from_secs(3))
         .build()?;
 
-    let mut span_processor = DeferSpanProcessor::new(512);
+    let mut span_processor = DeferSpanProcessor::new(batch_size.unwrap_or(512));
     span_processor
         .start(otlp_trace_exporter)
         .expect("Failed to start defer span processor");

--- a/proc-macros/derive-with-baggage/src/lib.rs
+++ b/proc-macros/derive-with-baggage/src/lib.rs
@@ -19,7 +19,6 @@ pub fn derive_with_baggage(input: TokenStream) -> TokenStream {
     // Generate the implementation of the `WithBaggage` trait.
     let expanded = match &input.data {
         Data::Enum(data_enum) => {
-            
             // Iterate over each variant of the enum.
             let match_arms = data_enum.variants.iter().map(|variant| {
                 let variant_name = &variant.ident;
@@ -31,7 +30,7 @@ pub fn derive_with_baggage(input: TokenStream) -> TokenStream {
                     // We only support named fields
                     Fields::Named(fields) => {
                         for field in &fields.named {
-                            
+
                             // Get field name and its attributes
                             let field_name = field.ident.as_ref().unwrap();
                             let has_baggage_attr = field.attrs.iter().any(|attr| attr.path().is_ident("baggage"));

--- a/src/app/basket_manager.rs
+++ b/src/app/basket_manager.rs
@@ -1,4 +1,4 @@
-use std::{fs, path::Path, sync::Arc, collections::HashSet};
+use std::{collections::HashSet, fs, path::Path, sync::Arc};
 
 use super::config::ConfigBuildError;
 use derive_builder::Builder;

--- a/src/app/order_sender.rs
+++ b/src/app/order_sender.rs
@@ -1,15 +1,122 @@
 use std::sync::Arc;
 
 use super::config::ConfigBuildError;
-use binance_order_sending::{binance_order_sending::BinanceOrderSending, credentials::Credentials};
+use binance_order_sending::{
+    binance_order_sending::BinanceOrderSending,
+    credentials::{self, Credentials},
+};
+use chrono::Utc;
 use derive_builder::Builder;
 use eyre::{eyre, OptionExt, Result};
+use itertools::Itertools;
 use parking_lot::RwLock;
 use rust_decimal::dec;
 use symm_core::{
-    core::bits::{Amount, Symbol},
-    order_sender::{inventory_manager::InventoryManager, order_tracker::OrderTracker},
+    core::{
+        self,
+        bits::{self, Amount, SingleOrder, Symbol},
+        functional::{
+            self, IntoObservableSingleVTable, NotificationHandlerOnce, PublishSingle,
+            SingleObserver,
+        },
+    },
+    order_sender::{
+        self,
+        inventory_manager::InventoryManager,
+        order_connector::{self, OrderConnector, OrderConnectorNotification, SessionId},
+        order_tracker::OrderTracker,
+        position::LotId,
+    },
 };
+
+struct SimpleOrderSender {
+    observer: SingleObserver<OrderConnectorNotification>,
+}
+
+impl SimpleOrderSender {
+    pub fn new() -> Self {
+        Self {
+            observer: SingleObserver::new(),
+        }
+    }
+
+    pub fn logon(&self) {
+        self.observer
+            .publish_single(OrderConnectorNotification::SessionLogon {
+                session_id: "Session-1".into(),
+                timestamp: Utc::now(),
+            });
+    }
+
+    pub fn stop(&self) {
+        self.observer
+            .publish_single(OrderConnectorNotification::SessionLogout {
+                session_id: "Session-1".into(),
+                reason: "Session ended".into(),
+                timestamp: Utc::now(),
+            });
+    }
+}
+
+impl OrderConnector for SimpleOrderSender {
+    fn send_order(&mut self, _session_id: SessionId, order: &Arc<SingleOrder>) -> Result<()> {
+        self.observer
+            .publish_single(OrderConnectorNotification::NewOrder {
+                order_id: order.order_id.clone(),
+                symbol: order.symbol.clone(),
+                side: order.side,
+                price: order.price,
+                quantity: order.quantity,
+                timestamp: order.created_timestamp,
+            });
+
+        self.observer
+            .publish_single(OrderConnectorNotification::Fill {
+                order_id: order.order_id.clone(),
+                symbol: order.symbol.clone(),
+                side: order.side,
+                price: order.price,
+                quantity: order.quantity,
+                timestamp: order.created_timestamp,
+                lot_id: format!("{}-L1", order.order_id).into(),
+                fee: Amount::ZERO,
+            });
+
+        self.observer
+            .publish_single(OrderConnectorNotification::Cancel {
+                order_id: order.order_id.clone(),
+                symbol: order.symbol.clone(),
+                side: order.side,
+                quantity: order.quantity,
+                timestamp: order.created_timestamp,
+            });
+
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+pub enum OrderSenderCredentials {
+    #[default]
+    Simple,
+    Binance(Vec<Credentials>),
+}
+
+enum OrderSenderVariant {
+    Simple(Arc<RwLock<SimpleOrderSender>>),
+    Binance(Arc<RwLock<BinanceOrderSending>>, Vec<Credentials>),
+}
+
+impl OrderSenderVariant {
+    fn get_order_connector(&self) -> Arc<RwLock<dyn OrderConnector + Send + Sync>> {
+        match self {
+            OrderSenderVariant::Simple(inner) => inner.clone(),
+            OrderSenderVariant::Binance(inner, _) => {
+                inner.clone() as Arc<RwLock<dyn OrderConnector + Send + Sync>>
+            }
+        }
+    }
+}
 
 #[derive(Builder)]
 #[builder(
@@ -27,13 +134,13 @@ pub struct OrderSenderConfig {
     pub with_inventory_manager: Option<bool>,
 
     #[builder(setter(into, strip_option), default)]
-    pub credentials: Vec<Credentials>,
+    pub credentials: OrderSenderCredentials,
 
     #[builder(setter(into, strip_option), default)]
     pub symbols: Vec<Symbol>,
 
     #[builder(setter(skip))]
-    order_sender: Option<Arc<RwLock<BinanceOrderSending>>>,
+    order_sender: Option<OrderSenderVariant>,
 
     #[builder(setter(skip))]
     order_tracker: Option<Arc<RwLock<OrderTracker>>>,
@@ -48,17 +155,23 @@ impl OrderSenderConfig {
         OrderSenderConfigBuilder::default()
     }
 
-    pub fn expect_order_sender_cloned(&self) -> Arc<RwLock<BinanceOrderSending>> {
+    pub fn expect_order_sender_cloned(&self) -> Arc<RwLock<dyn OrderConnector + Send + Sync>> {
         self.order_sender
-            .clone()
+            .as_ref()
             .ok_or(())
             .expect("Failed to get order sender")
+            .get_order_connector()
     }
 
-    pub fn try_get_order_sender_cloned(&self) -> Result<Arc<RwLock<BinanceOrderSending>>> {
-        self.order_sender
-            .clone()
-            .ok_or_eyre("Failed to get order sender")
+    pub fn try_get_order_sender_cloned(
+        &self,
+    ) -> Result<Arc<RwLock<dyn OrderConnector + Send + Sync>>> {
+        let order_sender_variant = self
+            .order_sender
+            .as_ref()
+            .ok_or_eyre("Failed to get order sender")?;
+
+        Ok(order_sender_variant.get_order_connector())
     }
 
     pub fn expect_order_tracker_cloned(&self) -> Arc<RwLock<OrderTracker>> {
@@ -88,21 +201,50 @@ impl OrderSenderConfig {
     }
 
     pub fn start(&mut self) -> Result<()> {
-        if let Some(order_sender) = &self.order_sender {
-            order_sender
-                .write()
-                .start(self.symbols.clone())
-                .map_err(|err| eyre!("Failed to start order sender: {:?}", err))?;
+        if let Some(order_sender) = &mut self.order_sender {
+            match order_sender {
+                OrderSenderVariant::Simple(order_sender) => {
+                    order_sender.read().logon();
+                }
+                OrderSenderVariant::Binance(order_sender, credentials) => {
+                    order_sender
+                        .write()
+                        .start(self.symbols.clone())
+                        .map_err(|err| eyre!("Failed to start order sender: {:?}", err))?;
 
-            order_sender
-                .write()
-                .logon(self.credentials.drain(..))
-                .map_err(|err| eyre!("Failed to logon: {:?}", err))?;
-
+                    order_sender
+                        .write()
+                        .logon(credentials.drain(..))
+                        .map_err(|err| eyre!("Failed to logon: {:?}", err))?;
+                }
+            }
             Ok(())
         } else {
             Err(eyre!(""))
         }
+    }
+
+    pub async fn stop(&mut self) -> Result<()> {
+        if let Some(order_sender) = &mut self.order_sender {
+            match order_sender {
+                OrderSenderVariant::Simple(order_sender) => {
+                    order_sender.read().stop();
+                }
+                OrderSenderVariant::Binance(order_sender, _) => {
+                    order_sender.write().stop().await?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl IntoObservableSingleVTable<OrderConnectorNotification> for SimpleOrderSender {
+    fn set_observer(
+        &mut self,
+        observer: Box<dyn NotificationHandlerOnce<OrderConnectorNotification>>,
+    ) {
+        self.observer.set_observer(observer);
     }
 }
 
@@ -110,8 +252,19 @@ impl OrderSenderConfigBuilder {
     pub fn build(self) -> Result<OrderSenderConfig, ConfigBuildError> {
         let mut config = self.try_build()?;
 
-        let order_sender = Arc::new(RwLock::new(BinanceOrderSending::new()));
-        config.order_sender.replace(order_sender.clone());
+        let order_sender_variant = match &mut config.credentials {
+            OrderSenderCredentials::Simple => {
+                OrderSenderVariant::Simple(Arc::new(RwLock::new(SimpleOrderSender::new())))
+            }
+            OrderSenderCredentials::Binance(credentials) => OrderSenderVariant::Binance(
+                Arc::new(RwLock::new(BinanceOrderSending::new())),
+                credentials.drain(..).collect_vec(),
+            ),
+        };
+
+        let order_sender = order_sender_variant.get_order_connector();
+
+        config.order_sender.replace(order_sender_variant);
 
         if config.with_order_tracker.unwrap_or(true) {
             let order_tracker = Arc::new(RwLock::new(OrderTracker::new(

--- a/src/app/order_sender.rs
+++ b/src/app/order_sender.rs
@@ -87,7 +87,7 @@ impl OrderConnector for SimpleOrderSender {
                 order_id: order.order_id.clone(),
                 symbol: order.symbol.clone(),
                 side: order.side,
-                quantity: order.quantity,
+                quantity: Amount::ZERO,
                 timestamp: order.created_timestamp,
             });
 

--- a/src/app/simple_server.rs
+++ b/src/app/simple_server.rs
@@ -22,15 +22,15 @@ impl SimpleServer {
             observer: MultiObserver::new(),
         }
     }
+
+    pub fn notify_server_event(&mut self, event: &Arc<ServerEvent>) {
+        self.observer.publish_many(event);
+    }
 }
 
 impl Server for SimpleServer {
     fn respond_with(&mut self, response: ServerResponse) {
         tracing::info!("Received response: {:?}", response);
-    }
-
-    fn publish_event(&mut self, event: &Arc<ServerEvent>) {
-        self.observer.publish_many(event);
     }
 }
 

--- a/src/app/solver.rs
+++ b/src/app/solver.rs
@@ -340,8 +340,6 @@ impl SolverConfig {
 
         order_sender
             .write()
-            .get_single_observer_arc()
-            .write()
             .set_observer_from(order_event_tx);
 
         order_tracker
@@ -485,11 +483,10 @@ impl SolverConfig {
 
     async fn stop_orders_backend(&mut self) -> Result<()> {
         if let Some((stop_backend_tx, backend_stopped_rx)) = self.stopping_backend.take() {
-            let order_sender = self.with_order_sender.try_get_order_sender_cloned()?;
-            order_sender.write().stop().await.unwrap();
+            self.with_order_sender.stop().await?;
 
-            stop_backend_tx.send(()).unwrap();
-            backend_stopped_rx.await.unwrap();
+            stop_backend_tx.send(())?;
+            backend_stopped_rx.await?;
 
             Ok(())
         } else {

--- a/src/blockchain/chain_connector.rs
+++ b/src/blockchain/chain_connector.rs
@@ -2,9 +2,9 @@ use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 
-use symm_core::core::telemetry::{TracingData, WithBaggage};
 use derive_with_baggage::WithBaggage;
 use opentelemetry::propagation::Injector;
+use symm_core::core::telemetry::{TracingData, WithBaggage};
 
 use symm_core::core::{
     bits::{Address, Amount, Symbol},
@@ -22,7 +22,7 @@ pub enum ChainNotification {
     Deposit {
         #[baggage]
         chain_id: u32,
-        
+
         #[baggage]
         address: Address,
 

--- a/src/collateral/collateral_manager.rs
+++ b/src/collateral/collateral_manager.rs
@@ -118,22 +118,22 @@ impl CollateralManager {
                     };
                     if unconfirmed_balance < request.collateral_amount {
                         tracing::debug!(
-                            "(collateral-manager) Awaiting deposit [{}:{}] {}: ca={} ub={}",
-                            request.chain_id,
-                            request.address,
-                            request.client_order_id,
-                            request.collateral_amount,
-                            unconfirmed_balance
+                            chain_id = %request.chain_id,
+                            address = %request.address,
+                            client_order_id = %request.client_order_id,
+                            collateral_amount = %request.collateral_amount,
+                            %unconfirmed_balance,
+                            "Awaiting deposit",
                         );
                         Either::Right(request)
                     } else {
                         tracing::debug!(
-                            "(collateral-manager) Ready to route [{}:{}] {}: ca={} ub={}",
-                            request.chain_id,
-                            request.address,
-                            request.client_order_id,
-                            request.collateral_amount,
-                            unconfirmed_balance
+                            chain_id = %request.chain_id,
+                            address = %request.address,
+                            client_order_id = %request.client_order_id,
+                            collateral_amount = %request.collateral_amount,
+                            %unconfirmed_balance,
+                            "Ready to route",
                         );
                         Either::Left(request)
                     }
@@ -169,7 +169,7 @@ impl CollateralManager {
 
         if !failures.is_empty() {
             tracing::warn!(
-                "(collateral-manager) Errors in processing: {}",
+                "Errors in processing: {}",
                 failures
                     .into_iter()
                     .map(|(err, request)| {
@@ -190,9 +190,10 @@ impl CollateralManager {
 
     pub fn manage_collateral(&mut self, collateral_management: CollateralManagement) {
         tracing::info!(
-            "(collateral-manager) ManageCollateral for {} {}",
-            collateral_management.address,
-            collateral_management.client_order_id
+            chain_id = %collateral_management.chain_id,
+            address = %collateral_management.address,
+            client_order_id = %collateral_management.client_order_id,
+            "Manage Collateral",
         );
         self.collateral_management_requests
             .push_back(collateral_management);
@@ -206,12 +207,8 @@ impl CollateralManager {
         amount: Amount,
         timestamp: DateTime<Utc>,
     ) -> Result<()> {
-        tracing::info!(
-            "(collateral-manager) Deposit from [{}:{}] {:0.5}",
-            chain_id,
-            address,
-            amount
-        );
+        tracing::info!(%chain_id, %address, %amount, "Deposit");
+
         let payment_id = host.get_next_payment_id();
         self.add_position(chain_id, address, timestamp)
             .write()
@@ -226,12 +223,8 @@ impl CollateralManager {
         amount: Amount,
         timestamp: DateTime<Utc>,
     ) -> Result<()> {
-        tracing::info!(
-            "(collateral-manager) Withdrawal from [{}:{}] {:0.5}",
-            chain_id,
-            address,
-            amount
-        );
+        tracing::info!(%chain_id, %address, %amount, "Withdrawal");
+
         let payment_id = host.get_next_payment_id();
         self.add_position(chain_id, address, timestamp)
             .write()
@@ -253,11 +246,7 @@ impl CollateralManager {
         side: Side,
         amount_payable: Amount,
     ) -> Result<()> {
-        tracing::info!(
-            "(collateral-manager) PreAuth Payment for {} {:0.5}",
-            address,
-            amount_payable
-        );
+        tracing::info!(%chain_id, %address, %amount_payable, "PreAuth Payment");
 
         let funds = self
             .get_position(chain_id, &address)
@@ -305,11 +294,7 @@ impl CollateralManager {
         side: Side,
         amount_paid: Amount,
     ) -> Result<()> {
-        tracing::info!(
-            "(collateral-manager) Confirm Payment for {} {:0.5}",
-            address,
-            amount_paid
-        );
+        tracing::info!(%chain_id, %address, %amount_paid, "Confirm Payment");
 
         let funds = self
             .get_position(chain_id, &address)
@@ -379,15 +364,9 @@ impl CollateralManager {
                 amount,
                 fee,
             } => {
-                tracing::info!(
-                    "(collateral-manager) Transfer Complete for {} {} {}: {} => {} {:0.5} {:0.5}",
-                    chain_id,
-                    address,
-                    client_order_id,
-                    transfer_from,
-                    transfer_to,
-                    amount,
-                    fee
+                tracing::info!(%chain_id, %address, %client_order_id,
+                    %transfer_from, %transfer_to, %amount, %fee,
+                    "Transfer Complete"
                 );
                 let funds = self
                     .get_position(chain_id, &address)

--- a/src/collateral/collateral_manager.rs
+++ b/src/collateral/collateral_manager.rs
@@ -127,7 +127,7 @@ impl CollateralManager {
                         );
                         Either::Right(request)
                     } else {
-                        tracing::debug!(
+                        tracing::info!(
                             chain_id = %request.chain_id,
                             address = %request.address,
                             client_order_id = %request.client_order_id,

--- a/src/collateral/collateral_manager.rs
+++ b/src/collateral/collateral_manager.rs
@@ -9,9 +9,9 @@ use parking_lot::RwLock;
 
 use eyre::{eyre, OptionExt, Result};
 
-use symm_core::core::telemetry::{TracingData, WithBaggage, WithTracingContext};
 use derive_with_baggage::WithBaggage;
 use opentelemetry::propagation::Injector;
+use symm_core::core::telemetry::{TracingData, WithBaggage, WithTracingContext};
 
 use symm_core::core::{
     bits::{Address, Amount, ClientOrderId, PaymentId, Side},
@@ -31,10 +31,10 @@ pub enum CollateralEvent {
     CollateralReady {
         #[baggage]
         chain_id: u32,
-        
+
         #[baggage]
         address: Address,
-        
+
         #[baggage]
         client_order_id: ClientOrderId,
 
@@ -59,13 +59,13 @@ pub enum CollateralEvent {
     ConfirmResponse {
         #[baggage]
         chain_id: u32,
-        
+
         #[baggage]
         address: Address,
-        
+
         #[baggage]
         client_order_id: ClientOrderId,
-        
+
         #[baggage]
         payment_id: PaymentId,
 

--- a/src/collateral/collateral_position.rs
+++ b/src/collateral/collateral_position.rs
@@ -168,9 +168,13 @@ impl CollateralSide {
             lot.unconfirmed_amount = unconfirmed_balance;
             lot.ready_amount = ready_balance;
             tracing::info!(
-                "(colateral-side) AddReady for {} {:0.5} ua={:0.5} ra={:0.5} pa={:0.5} sa={:0.5} (partial confirm)",
-                lot.payment_id, amount, lot.unconfirmed_amount, lot.ready_amount, lot.preauth_amount, lot.spent_amount
-            );
+                payment_id = %lot.payment_id,
+                %amount,
+                unconfirmed_amount = %lot.unconfirmed_amount,
+                ready_amount = %lot.ready_amount,
+                preauth_amount = %lot.preauth_amount,
+                spent_amount = %lot.spent_amount,
+                "AddReady (partial confirm)");
         }
 
         for lot in self.open_lots.iter_mut().take(pos) {
@@ -180,9 +184,13 @@ impl CollateralSide {
             lot.ready_amount = ready_balance;
             lot.last_update_timestamp = timestamp;
             tracing::info!(
-                "(colateral-side) AddReady for {} {:0.5} ua={:0.5} ra={:0.5} pa={:0.5} sa={:0.5} (full confirm)",
-                lot.payment_id, amount, lot.unconfirmed_amount, lot.ready_amount, lot.preauth_amount, lot.spent_amount
-            );
+                payment_id = %lot.payment_id,
+                %amount,
+                unconfirmed_amount = %lot.unconfirmed_amount,
+                ready_amount = %lot.ready_amount,
+                preauth_amount = %lot.preauth_amount,
+                spent_amount = %lot.spent_amount,
+                "AddReady (full confirm)");
         }
 
         let ready_balance = safe!(self.ready_balance + amount_deliverable)?;
@@ -236,9 +244,15 @@ impl CollateralSide {
                 timestamp,
             };
             tracing::info!(
-                "(colateral-side) PreAuth for {} [{}] {} {:0.5} ua={:0.5} ra={:0.5} pa={:0.5} sa={:0.5} (partial preauth)",
-                lot.payment_id, spend.payment_id, spend.client_order_id, spend.preauth_amount,
-                lot.unconfirmed_amount, lot.ready_amount, lot.preauth_amount, lot.spent_amount
+                payment_id = %lot.payment_id,
+                payment_id = %spend.payment_id,
+                client_order_id = %spend.client_order_id,
+                preauth_amount = %spend.preauth_amount,
+                unconfirmed_amount = %lot.unconfirmed_amount,
+                ready_amount = %lot.ready_amount,
+                preauth_amount = %lot.preauth_amount,
+                spent_amount = %lot.spent_amount,
+                "PreAuth (partial preauth)",
             );
             lot.spends.push(spend);
         }
@@ -257,9 +271,15 @@ impl CollateralSide {
                 timestamp,
             };
             tracing::info!(
-                "(colateral-side) PreAuth for {} [{}] {} {:0.5} ua={:0.5} ra={:0.5} pa={:0.5} sa={:0.5} (full preauth)",
-                lot.payment_id, spend.payment_id, spend.client_order_id, spend.preauth_amount,
-                lot.unconfirmed_amount, lot.ready_amount, lot.preauth_amount, lot.spent_amount
+                payment_id = %lot.payment_id,
+                payment_id = %spend.payment_id,
+                client_order_id = %spend.client_order_id,
+                preauth_amount = %spend.preauth_amount,
+                unconfirmed_amount = %lot.unconfirmed_amount,
+                ready_amount = %lot.ready_amount,
+                preauth_amount = %lot.preauth_amount,
+                spent_amount = %lot.spent_amount,
+                "PreAuth (full preauth)",
             );
             lot.spends.push(spend);
         }
@@ -341,18 +361,26 @@ impl CollateralSide {
                 && lot.preauth_amount < zero_threshold
             {
                 tracing::info!(
-                    "(colateral-side) Spend for {} [{}] {:0.5} ua={:0.5} ra={:0.5} pa={:0.5} sa={:0.5} (full spend)",
-                        lot.payment_id, payment_id, amount,
-                        lot.unconfirmed_amount, lot.ready_amount, lot.preauth_amount, lot.spent_amount
-                    );
+                    lot_payment_id = %lot.payment_id,
+                    %payment_id,
+                    %amount,
+                    unconfirmed_amount = %lot.unconfirmed_amount,
+                    ready_amount = %lot.ready_amount,
+                    preauth_amount = %lot.preauth_amount,
+                    spent_amount = %lot.spent_amount,
+                    "Spend (full spend)");
 
                 closed_lots.push_back(lot.payment_id.clone());
             } else {
                 tracing::info!(
-                    "(colateral-side) Spend for {} [{}] {:0.5} ua={:0.5} ra={:0.5} pa={:0.5} sa={:0.5} (partial spend)",
-                        lot.payment_id, payment_id, amount,
-                        lot.unconfirmed_amount, lot.ready_amount, lot.preauth_amount, lot.spent_amount
-                    );
+                    lot_payment_id = %lot.payment_id,
+                    payment_id = %payment_id,
+                    %amount,
+                    unconfirmed_amount = %lot.unconfirmed_amount,
+                    ready_amount = %lot.ready_amount,
+                    preauth_amount = %lot.preauth_amount,
+                    spent_amount = %lot.spent_amount,
+                    "Spend (partial spend)");
             }
         }
 
@@ -392,9 +420,14 @@ impl CollateralSide {
             lot.spent_amount = spent_balance;
 
             tracing::info!(
-                "(colateral-side) Spend for {} [{}] {:0.5} ua={:0.5} ra={:0.5} pa={:0.5} sa={:0.5} (partial spend *)",
-                lot.payment_id, payment_id, amount,
-                lot.unconfirmed_amount, lot.ready_amount, lot.preauth_amount, lot.spent_amount
+                lot_payment_id = %lot.payment_id,
+                %payment_id,
+                %amount,
+                unconfirmed_amount = %lot.unconfirmed_amount,
+                ready_amount = %lot.ready_amount,
+                preauth_amount = %lot.preauth_amount,
+                spent_amount = %lot.spent_amount,
+                "Spend (partial spend *)",
             );
         }
 

--- a/src/collateral/collateral_router.rs
+++ b/src/collateral/collateral_router.rs
@@ -250,7 +250,7 @@ impl CollateralRouter {
             %source,
             %route_from,
             %route_to,
-            "(collateral-router) Found route: {}",
+            "Found route: {}",
             route.iter().join(", ")
         );
 

--- a/src/collateral/collateral_router.rs
+++ b/src/collateral/collateral_router.rs
@@ -247,6 +247,9 @@ impl CollateralRouter {
             .ok_or_eyre("Route not found")?;
 
         tracing::info!(
+            %source,
+            %route_from,
+            %route_to,
             "(collateral-router) Found route: {}",
             route.iter().join(", ")
         );
@@ -285,16 +288,10 @@ impl CollateralRouter {
                 fee,
             } => {
                 if route_to.eq(&destination) {
-                    tracing::info!(
-                        "(collateral-router) Route Complete for [{}:{}] {}: {} => {} {:0.5} {:0.5}",
-                        chain_id,
-                        address,
-                        client_order_id,
-                        route_from,
-                        route_to,
-                        amount,
-                        fee
-                    );
+                    tracing::info!(%chain_id, %address, %client_order_id, %route_from, %route_to,
+                        %amount, %fee,
+                        "Route Complete");
+
                     self.observer
                         .publish_single(CollateralTransferEvent::TransferComplete {
                             chain_id,
@@ -312,19 +309,15 @@ impl CollateralRouter {
                     let next_hop = next_hop
                         .write()
                         .map_err(|e| eyre!("Failed to access next hop {}", e))?;
-                    tracing::info!(
-                        "(collateral-router) Route Hop for [{}:{}] {}: ({}) {} .. [{}] => {} ({}) {:0.5} {:0.5}",
-                        chain_id,
-                        address,
-                        client_order_id,
-                        route_from,
-                        source,
-                        next_hop.get_source().read().map(|x| x.get_full_name()).unwrap_or_default(),
-                        next_hop.get_destination().read().map(|x| x.get_full_name()).unwrap_or_default(),
-                        route_to,
-                        amount,
-                        fee
-                    );
+
+                    tracing::info!(%chain_id, %address, %client_order_id, %route_from, %route_to,
+                        %source,
+                        next_source = %next_hop.get_source().read().map(|x| x.get_full_name()).unwrap_or_default(),
+                        next_destination = %next_hop.get_destination().read().map(|x| x.get_full_name()).unwrap_or_default(),
+                        %amount,
+                        %fee,
+                        "Route Hop");
+
                     next_hop.transfer_funds(
                         chain_id,
                         address,

--- a/src/collateral/collateral_router.rs
+++ b/src/collateral/collateral_router.rs
@@ -8,12 +8,10 @@ use itertools::Itertools;
 
 use eyre::{eyre, OptionExt, Result};
 
-use symm_core::core::telemetry::{TracingData, WithBaggage, WithTracingContext};
 use derive_with_baggage::WithBaggage;
 use opentelemetry::propagation::Injector;
+use symm_core::core::telemetry::{TracingData, WithBaggage};
 
-
-use serde::Serialize;
 use symm_core::core::{
     bits::{Address, Amount, ClientOrderId, Side, Symbol},
     functional::{IntoObservableSingle, IntoObservableSingleVTable, PublishSingle, SingleObserver},
@@ -44,10 +42,10 @@ pub enum CollateralRouterEvent {
     HopComplete {
         #[baggage]
         chain_id: u32,
-        
+
         #[baggage]
         address: Address,
-        
+
         #[baggage]
         client_order_id: ClientOrderId,
 

--- a/src/index/basket_manager.rs
+++ b/src/index/basket_manager.rs
@@ -34,11 +34,8 @@ impl BasketManager {
 
     pub fn notify_baskets(&self) -> Result<()> {
         if self.observer.has_observer() {
-           for (symbol, basket) in &self.baskets {
-                let event = BasketNotification::BasketUpdated(
-                    symbol.clone(),
-                    basket.clone(),
-                );
+            for (symbol, basket) in &self.baskets {
+                let event = BasketNotification::BasketUpdated(symbol.clone(), basket.clone());
                 self.observer.publish_single(event);
             }
             Ok(())

--- a/src/server/fix/messages.rs
+++ b/src/server/fix/messages.rs
@@ -99,7 +99,6 @@ pub enum RequestBody {
     CustodyToAccountBody,
 }
 
-
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(untagged)]
 pub enum ResponseBody {

--- a/src/server/fix/requests.rs
+++ b/src/server/fix/requests.rs
@@ -246,9 +246,9 @@ impl AxumServerRequest for FixRequest {
         // Set the session_id
         request.session_id = this_session_id.clone();
         tracing::info!(
-            "FIX server request received from {}: {}",
-            request.session_id,
-            request.standard_header.msg_type
+            session_id = %request.session_id,
+            msg_type = %request.standard_header.msg_type,
+            "FIX server request received",
         );
         Ok(request)
     }

--- a/src/server/fix/responses.rs
+++ b/src/server/fix/responses.rs
@@ -76,14 +76,14 @@ impl AxumServerResponse for FixResponse {
     }
 
     fn serialize_into_fix(&self) -> Result<FixMessage> {
-        // Serialize the response to JSON
         let json_str =
             serde_json::to_string(self).map_err(|e| eyre!("Failed to serialize message: {}", e))?;
+
         tracing::info!(
+            session_id = %self.session_id,
+            msg_type = %self.standard_header.msg_type,
             json_data = %json_str,
-            "FIX server response sent to {}: {}",
-            self.session_id,
-            self.standard_header.msg_type
+            "FIX server response sent",
         );
         Ok(FixMessage(json_str.to_owned()))
     }

--- a/src/server/fix/responses.rs
+++ b/src/server/fix/responses.rs
@@ -40,11 +40,7 @@ impl FixResponse {
         }
     }
 
-    pub fn create_ack(
-        user_id: &(u32, Address),
-        session_id: &SessionId,
-        seq_num: u32,
-    ) -> Self {
+    pub fn create_ack(user_id: &(u32, Address), session_id: &SessionId, seq_num: u32) -> Self {
         FixResponse {
             session_id: session_id.clone(),
             standard_header: FixHeader::new("ACK".to_string()),
@@ -101,11 +97,7 @@ impl AxumServerResponse for FixResponse {
         FixResponse::create_nak(user_id, session_id, ref_seq_num, error_msg)
     }
 
-    fn format_ack(
-        user_id: &(u32, Address),
-        session_id: &SessionId,
-        ref_seq_num: u32,
-    ) -> Self {
+    fn format_ack(user_id: &(u32, Address), session_id: &SessionId, ref_seq_num: u32) -> Self {
         FixResponse::create_ack(user_id, session_id, ref_seq_num)
     }
 }

--- a/src/server/fix/server.rs
+++ b/src/server/fix/server.rs
@@ -42,8 +42,4 @@ impl ServerInterface for Server {
             tracing::warn!("Failed to respond with: {:?}", err);
         }
     }
-
-    fn publish_event(&mut self, event: &Arc<ServerEvent>) {
-        tracing::warn!("publish_event is not supported for this Server implementation");
-    }
 }

--- a/src/server/fix/server_plugin.rs
+++ b/src/server/fix/server_plugin.rs
@@ -89,7 +89,8 @@ impl ServerPlugin {
                         || side == "BUY"
                         || side == "bid"
                         || side == "Bid"
-                        || side == "BID" {
+                        || side == "BID"
+                    {
                         Side::Buy
                     } else if side == "2"
                         || side == "s"
@@ -99,12 +100,12 @@ impl ServerPlugin {
                         || side == "SELL"
                         || side == "ask"
                         || side == "Ask"
-                        || side == "ASK" {
+                        || side == "ASK"
+                    {
                         Side::Sell
                     } else {
                         return Err(eyre!("Invalid side value"));
-                    }
-                    ;
+                    };
                     let collateral_amount = amount
                         .parse()
                         .ok()
@@ -163,7 +164,8 @@ impl ServerPlugin {
                         || side == "BUY"
                         || side == "bid"
                         || side == "Bid"
-                        || side == "BID" {
+                        || side == "BID"
+                    {
                         Side::Buy
                     } else if side == "2"
                         || side == "s"
@@ -173,7 +175,8 @@ impl ServerPlugin {
                         || side == "SELL"
                         || side == "ask"
                         || side == "Ask"
-                        || side == "ASK" {
+                        || side == "ASK"
+                    {
                         Side::Sell
                     } else {
                         return Err(eyre!("Invalid side value"));

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -4,9 +4,9 @@ use chrono::{DateTime, Utc};
 use serde::Serialize;
 use thiserror::Error;
 
-use symm_core::core::telemetry::{TracingData, WithBaggage};
 use derive_with_baggage::WithBaggage;
 use opentelemetry::propagation::Injector;
+use symm_core::core::telemetry::{TracingData, WithBaggage};
 
 use symm_core::core::{
     bits::{Address, Amount, ClientOrderId, ClientQuoteId, Side, Symbol},
@@ -20,10 +20,10 @@ pub enum ServerEvent {
     NewIndexOrder {
         #[baggage]
         chain_id: u32,
-        
+
         #[baggage]
         address: Address,
-        
+
         #[baggage]
         client_order_id: ClientOrderId,
 
@@ -35,10 +35,10 @@ pub enum ServerEvent {
     CancelIndexOrder {
         #[baggage]
         chain_id: u32,
-        
+
         #[baggage]
         address: Address,
-        
+
         #[baggage]
         client_order_id: ClientOrderId,
 
@@ -49,10 +49,10 @@ pub enum ServerEvent {
     NewQuoteRequest {
         #[baggage]
         chain_id: u32,
-        
+
         #[baggage]
         address: Address,
-        
+
         #[baggage]
         client_quote_id: ClientQuoteId,
 
@@ -64,10 +64,10 @@ pub enum ServerEvent {
     CancelQuoteRequest {
         #[baggage]
         chain_id: u32,
-        
+
         #[baggage]
         address: Address,
-        
+
         #[baggage]
         client_quote_id: ClientQuoteId,
 
@@ -85,7 +85,7 @@ pub enum NewIndexOrderNakReason {
 
     #[error("Invalid symbol: {detail:?}")]
     InvalidSymbol { detail: String },
-    
+
     #[error("Other reason: {detail:?}")]
     OtherReason { detail: String },
 }

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -238,9 +238,6 @@ pub enum ServerResponse {
 pub trait Server: IntoObservableManyVTable<Arc<ServerEvent>> + Send + Sync {
     /// Provide methods for sending FIX responses
     fn respond_with(&mut self, response: ServerResponse);
-
-    /// Publish a server event
-    fn publish_event(&mut self, event: &Arc<ServerEvent>);
 }
 
 pub mod test_util {
@@ -284,10 +281,6 @@ pub mod test_util {
         /// provide methods for sending FIX responses
         fn respond_with(&mut self, response: ServerResponse) {
             self.implementor.publish_single(response);
-        }
-
-        fn publish_event(&mut self, event: &Arc<ServerEvent>) {
-            self.observer.publish_many(event);
         }
     }
 

--- a/src/solver/batch_manager.rs
+++ b/src/solver/batch_manager.rs
@@ -689,13 +689,13 @@ impl BatchManager {
 
             // = Quantity available in this batch for this Index Order
             //  / Quantity required to fully fill the fraction of the whole Index Order requested in this batch
-            let avialable_fill_rate =
+            let available_fill_rate =
                 safe!(available_quantity / asset_quantity).ok_or_eyre("Math Problem")?;
 
             // We're finding lowest fill-rate for this Index Order across all assets, because
             // we cannot fill this Index Order more than least available asset fill-rate.
-            fill_rate = fill_rate.map_or(Some(avialable_fill_rate), |x: Amount| {
-                Some(x.min(avialable_fill_rate))
+            fill_rate = fill_rate.map_or(Some(available_fill_rate), |x: Amount| {
+                Some(x.min(available_fill_rate))
             });
             tracing::info!(
                 chain_id = %index_order_write.chain_id,
@@ -703,10 +703,10 @@ impl BatchManager {
                 client_order_id = %index_order_write.client_order_id,
                 %asset_symbol,
                 %asset_quantity,
-                %position.position,
+                position = %position.position,
                 %available_quantity,
                 %contribution_fraction,
-                %avialable_fill_rate,
+                %available_fill_rate,
                 "Fill Basket Asset",
             );
         }

--- a/src/solver/batch_manager.rs
+++ b/src/solver/batch_manager.rs
@@ -8,6 +8,7 @@ use eyre::{eyre, OptionExt, Result};
 use itertools::Itertools;
 use parking_lot::{Mutex, RwLock};
 use safe_math::safe;
+use serde_json::json;
 use tracing::{span, Level};
 
 use crate::solver::solver_order::SolverOrderStatus;
@@ -179,13 +180,13 @@ impl BatchAssetPosition {
             let lot_collateral_spent = asset_allocation.compute_collateral_spent()?;
             collateral_spent = safe!(collateral_spent + lot_collateral_spent)?;
             tracing::info!(
-                "(batch-asset-position) IndexOrder allocation for {} {} {} q={:0.5} p={:0.5} fee={:0.5}",
-                index_order.client_order_id,
-                asset_allocation.lot_id,
-                asset_allocation.symbol,
-                asset_allocation.quantity,
-                asset_allocation.price,
-                asset_allocation.fee
+                client_order_id = %index_order.client_order_id,
+                lot_id = %asset_allocation.lot_id,
+                symbol = %asset_allocation.symbol,
+                quantity = %asset_allocation.quantity,
+                price = %asset_allocation.price,
+                fee = %asset_allocation.fee,
+                "IndexOrder allocation",
             );
             index_order.lots.push(asset_allocation);
             Some(())
@@ -342,24 +343,24 @@ impl BatchOrderStatus {
         .ok_or_eyre("Math Problem")?;
 
         tracing::info!(
-            "(batch-manager) Batch Position: {:?} {:5} total={:0.5} volley={:0.5} pos={:0.5} real={:0.5} + fee={:0.5}",
-            position.side,
-            position.symbol,
-            position.order_quantity,
-            position.volley_size,
-            position.position,
-            position.realized_value,
-            position.fee
+            side = ?position.side,
+            symbol = %position.symbol,
+            order_quantity = %position.order_quantity,
+            volley_size = %position.volley_size,
+            position = %position.position,
+            realized_value = %position.realized_value,
+            fee = %position.fee,
+            "Batch Position",
         );
 
         tracing::info!(
-            "(batch-manager) Batch Status: {} volley={:0.5} fill={:0.5} frac={:0.5} real={:0.5} fee={:0.5}",
-            batch_order_id,
-            self.volley_size,
-            self.filled_volley,
-            self.filled_fraction,
-            self.realized_value,
-            self.fee
+            batch_order_id = %batch_order_id,
+            volley_size = %self.volley_size,
+            filled_volley = %self.filled_volley,
+            filled_fraction = %self.filled_fraction,
+            realized_value = %self.realized_value,
+            fee = %self.fee,
+            "Batch Status"
         );
 
         Ok(())
@@ -389,8 +390,8 @@ impl BatchOrderStatus {
             .all(|position| position.is_cancelled)
         {
             tracing::info!(
-                "(batch-manager) Batch is all cancelled {}",
-                self.batch_order_id
+                batch_order_id = %self.batch_order_id,
+                "Batch is all cancelled",
             );
             self.is_cancelled = true;
         }
@@ -411,10 +412,10 @@ impl BatchOrderStatus {
                     let carried_position =
                         carried_lots.iter().map(|lot| lot.remaining_quantity).sum();
                     tracing::info!(
-                        "(batch-order-status) Carried over {} {:?} {:0.5}",
-                        symbol,
-                        side,
-                        carried_position
+                        symbol = %symbol,
+                        side = ?side,
+                        carried_position = %carried_position,
+                        "Carried over",
                     );
 
                     match carry_overs.entry((symbol.clone(), *side)) {
@@ -619,16 +620,11 @@ impl BatchManager {
         self.adjust_order_batch(&mut batch, carried_positions)?;
 
         tracing::info!(
-            "(batch-manager) Sending Batch: {}",
-            batch
-                .asset_orders
-                .iter()
-                .map(|ba| format!(
-                    "{:?} {}: {:0.5} @ {:0.5}",
-                    ba.side, ba.symbol, ba.quantity, ba.price
-                ))
-                .join("; ")
-        );
+            batch = %json!(batch.asset_orders.iter()
+                .map(|ba| (ba.side, json!(ba.symbol), ba.quantity, ba.price))
+                .collect_vec()
+            ),
+            "Sending Batch");
 
         *self.total_volley_size.write() += batch_order_status.volley_size;
 
@@ -702,13 +698,16 @@ impl BatchManager {
                 Some(x.min(avialable_fill_rate))
             });
             tracing::info!(
-                "(batch-manager) Fill Basket Asset: {:5} q={:0.5} pos={:0.5} aq={:0.5} cf={:0.5} afr={:0.5}",
-                asset_symbol,
-                asset_quantity,
-                position.position,
-                available_quantity,
-                contribution_fraction,
-                avialable_fill_rate
+                chain_id = %index_order_write.chain_id,
+                address = %index_order_write.address,
+                client_order_id = %index_order_write.client_order_id,
+                %asset_symbol,
+                %asset_quantity,
+                %position.position,
+                %available_quantity,
+                %contribution_fraction,
+                %avialable_fill_rate,
+                "Fill Basket Asset",
             );
         }
 
@@ -810,15 +809,18 @@ impl BatchManager {
             .ok_or_eyre("Math Problem")?;
 
         tracing::info!(
-            "(batch-manager) Fill Index Order: ifq={:0.5} irc={:0.5} iec={:0.5} ics={:0.5} cs={:0.5} rc={:0.5} bfr={:0.3}% ofr={:0.3}%",
-            index_order_write.filled_quantity,
-            index_order_write.remaining_collateral,
-            index_order_write.engaged_collateral,
-            index_order_write.collateral_spent,
-            collateral_spent,
-            remaining_collateral,
-            safe!(fill_rate * Amount::ONE_HUNDRED).unwrap_or_default(),
-            safe!(order_fill_rate * Amount::ONE_HUNDRED).unwrap_or_default(),
+            chain_id = %index_order_write.chain_id,
+            address = %index_order_write.address,
+            client_order_id = %index_order_write.client_order_id,
+            filled_quantity = %index_order_write.filled_quantity,
+            remaining_collateral = %index_order_write.remaining_collateral,
+            engaged_collateral = %index_order_write.engaged_collateral,
+            collateral_spent = %index_order_write.collateral_spent,
+            calculated_collateral_spent = %collateral_spent,
+            calculated_remaining_collateral = %remaining_collateral,
+            %fill_rate,
+            %order_fill_rate,
+            "Fill Index Order",
         );
 
         host.fill_order_request(
@@ -843,10 +845,12 @@ impl BatchManager {
 
         if self.fill_threshold < order_fill_rate {
             tracing::info!(
-                "(batch-manager) Index Order {} fill-rate {:0.5} is above fill threshold {:0.5}",
-                index_order_write.client_order_id,
-                order_fill_rate,
-                self.fill_threshold
+                chain_id = %index_order_write.chain_id,
+                address = %index_order_write.address,
+                client_order_id = %index_order_write.client_order_id,
+                %order_fill_rate,
+                fill_threshold = %self.fill_threshold,
+                "Index Order fill-rate is above fill threshold",
             );
             host.set_order_status(&mut index_order_write, SolverOrderStatus::FullyMintable);
         }
@@ -983,8 +987,8 @@ impl BatchManager {
         let _guard = handle_engage_span.enter();
 
         tracing::info!(
-            "(batch-manager) Handle Index Order EngageIndexOrder {}",
-            batch_order_id
+            %batch_order_id,
+            "Handle Index Order EngageIndexOrder",
         );
         match self.engagements.get(&batch_order_id) {
             Some(engaged_orders_stored) => {
@@ -1154,15 +1158,17 @@ impl BatchManager {
                 if self.zero_threshold < collateral_carried {
                     if let SolverOrderStatus::FullyMintable = index_order.status {
                         tracing::info!(
-                            "(batch-manager) Index Order is Fully Mintable {} cc={:0.5}",
-                            engaged_order.client_order_id,
-                            collateral_carried
+                            chain_id = %engaged_order.chain_id,
+                            address = %engaged_order.address,
+                            client_order_id = %engaged_order.client_order_id,
+                            %collateral_carried,
+                            "Index Order is Fully Mintable",
                         );
                     } else {
                         tracing::info!(
-                            "(batch-manager) Will continue Index Order {} cc={:0.5}",
-                            engaged_order.client_order_id,
-                            collateral_carried
+                            client_order_id = %engaged_order.client_order_id,
+                            %collateral_carried,
+                            "Will continue Index Order",
                         );
                         index_order.with_upgraded(|index_order_write| {
                             index_order_write.collateral_carried = collateral_carried;

--- a/src/solver/index_order_manager.rs
+++ b/src/solver/index_order_manager.rs
@@ -10,7 +10,7 @@ use safe_math::safe;
 
 use derive_with_baggage::WithBaggage;
 use opentelemetry::propagation::Injector;
-use symm_core::core::telemetry::{TracingData, WithBaggage, WithTracingContext};
+use symm_core::core::telemetry::{TracingData, WithBaggage};
 
 use crate::{
     server::server::{

--- a/src/solver/solver.rs
+++ b/src/solver/solver.rs
@@ -9,6 +9,7 @@ use itertools::Itertools;
 use parking_lot::{Mutex, RwLock};
 use safe_math::safe;
 
+use serde_json::json;
 use symm_core::{
     core::{
         bits::{
@@ -24,7 +25,7 @@ use symm_core::{
     },
     order_sender::inventory_manager::{InventoryEvent, InventoryManager},
 };
-use tracing::{span, Instrument, Level};
+use tracing::{span, Level};
 
 use crate::{
     blockchain::chain_connector::{ChainConnector, ChainNotification},
@@ -249,11 +250,11 @@ impl Solver {
                 SolverOrderStatus::MissingPrices => {
                     (|o: &SolverOrder| {
                         tracing::warn!(
-                            "(solver) Missing prices for order [{}:{}] {} {}",
-                            o.chain_id,
-                            o.address,
-                            o.client_order_id,
-                            o.symbol
+                            chain_id = %o.chain_id,
+                            address = %o.address,
+                            client_order_id = %o.client_order_id,
+                            symbol = %o.symbol,
+                            "Missing prices for order",
                         );
                     })(&failed_order.read());
                     self.client_orders.write().put_back(failed_order);
@@ -261,11 +262,11 @@ impl Solver {
                 _ => {
                     let o = failed_order.read();
                     tracing::warn!(
-                        "(solver) Failed order [{}:{}] {} {} Reason: {:?}",
-                        o.chain_id,
-                        o.address,
-                        o.client_order_id,
-                        o.symbol,
+                        chain_id = %o.chain_id,
+                        address = %o.address,
+                        client_order_id = %o.client_order_id,
+                        symbol = %o.symbol,
+                        "Failed order: {:?}",
                         failed_status
                     );
                     self.index_order_manager
@@ -474,65 +475,65 @@ impl Solver {
 
     /// Core thinking function
     pub fn solve(&self, timestamp: DateTime<Utc>) {
-        tracing::trace!("\n(solver) Begin solve");
+        tracing::trace!("\nBegin solve");
 
-        tracing::trace!("(solver) * Process collateral");
+        tracing::trace!("* Process collateral");
         if let Err(err) = self
             .collateral_manager
             .write()
             .map_err(|e| eyre!("Failed to access collateral manager {}", e))
             .and_then(|mut x| x.process_collateral(self, timestamp))
         {
-            tracing::warn!("(solver) Error while processing credits: {:?}", err);
+            tracing::warn!("Error while processing credits: {:?}", err);
         }
 
-        tracing::trace!("(solver) * Mint indexes");
+        tracing::trace!("* Mint indexes");
         if let Err(err) = self.mint_indexes(timestamp) {
-            tracing::warn!("(solver) Error while processing mints: {:?}", err);
+            tracing::warn!("Error while processing mints: {:?}", err);
         }
 
-        tracing::trace!("(solver) * Serve more clients");
+        tracing::trace!("* Serve more clients");
         if let Err(err) = self.serve_more_clients(timestamp) {
-            tracing::warn!("(solver) Error while serving more clients: {:?}", err);
+            tracing::warn!("Error while serving more clients: {:?}", err);
         }
 
-        tracing::trace!("(solver) * Engage more orders");
+        tracing::trace!("* Engage more orders");
         if let Err(err) = self.engage_more_orders(timestamp) {
             tracing::warn!("Error while engaging more orders: {:?}", err);
         }
 
-        tracing::trace!("(solver) * Process batches");
+        tracing::trace!("* Process batches");
         if let Err(err) = self
             .batch_manager
             .write()
             .map_err(|e| eyre!("Failed to access batch manager {}", e))
             .and_then(|mut x| x.process_batches(self, timestamp))
         {
-            tracing::warn!("(solver) Error while sending more batches: {:?}", err);
+            tracing::warn!("Error while sending more batches: {:?}", err);
         }
 
-        tracing::trace!("(solver) * Process quotes");
+        tracing::trace!("* Process quotes");
         if let Err(err) = self.process_more_quotes(timestamp) {
-            tracing::warn!("(solver) Error while processing more quotes: {:?}", err);
+            tracing::warn!("Error while processing more quotes: {:?}", err);
         }
 
-        tracing::trace!("(solver) End solve\n");
+        tracing::trace!("End solve\n");
     }
 
     pub fn solve_quotes(&self, timestamp: DateTime<Utc>) {
-        tracing::trace!("\n(solver) Begin solve quotes");
+        tracing::trace!("\nBegin solve quotes");
 
         if let Err(err) = self.process_more_quotes(timestamp) {
-            tracing::warn!("(solver) Error while processing more quotes: {:?}", err);
+            tracing::warn!("Error while processing more quotes: {:?}", err);
         }
 
-        tracing::trace!("(solver) End solve quotes\n");
+        tracing::trace!("End solve quotes\n");
     }
 
     pub fn handle_chain_event(&self, notification: ChainNotification) -> Result<()> {
         match notification {
             ChainNotification::CuratorWeightsSet(symbol, basket_definition) => {
-                tracing::info!("(solver) Handle Chain Event CuratorWeigthsSet {}", symbol);
+                tracing::info!(%symbol, "Handle Chain Event CuratorWeigthsSet");
                 let symbols = basket_definition
                     .weights
                     .iter()
@@ -546,20 +547,21 @@ impl Solver {
 
                 if !get_prices_response.missing_symbols.is_empty() {
                     tracing::info!(
-                        "(solver) No prices available for some symbols: {:?}",
-                        get_prices_response.missing_symbols
+                        %symbol,
+                        missing_symbols = %json!(get_prices_response.missing_symbols),
+                        "No prices available for some symbols"
                     );
                 }
 
                 let target_price = "1000".try_into().unwrap(); // TODO
 
                 if let Err(err) = self.basket_manager.write().set_basket_from_definition(
-                    symbol,
+                    symbol.clone(),
                     basket_definition,
                     &get_prices_response.prices,
                     target_price,
                 ) {
-                    tracing::warn!("(solver) Error while setting curator weights: {err}");
+                    tracing::warn!(%symbol, "Error while setting curator weights: {err}");
                 }
                 Ok(())
             }
@@ -592,12 +594,12 @@ impl Solver {
                 batch_order_id,
                 continued_orders,
             } => {
-                tracing::info!("(solver) Handle Batch Complete {}", batch_order_id);
+                tracing::info!(%batch_order_id, "Handle Batch Complete");
                 self.ready_orders.lock().extend(continued_orders);
                 Ok(())
             }
             BatchEvent::BatchMintable { mintable_orders } => {
-                tracing::info!("(solver) Handle Batch Mintable");
+                tracing::info!("Handle Batch Mintable");
                 self.ready_mints.lock().extend(mintable_orders);
                 Ok(())
             }
@@ -614,13 +616,8 @@ impl Solver {
                 fee,
                 timestamp,
             } => {
-                tracing::info!(
-                    "(solver) CollateralReady for {} {} {:0.5} {:0.5}",
-                    chain_id,
-                    address,
-                    collateral_amount,
-                    fee
-                );
+                tracing::info!(%chain_id, %address, %collateral_amount, %fee,
+                    "CollateralReady");
 
                 let order = self.client_orders.read().get_client_order(
                     chain_id,
@@ -683,7 +680,7 @@ impl Solver {
                         );
 
                         if let Some(order) = order {
-                            tracing::info!("(solver) PreAuth approved: {}", payment_id);
+                            tracing::info!(%payment_id, "PreAuth approved");
                             let mut order_write = order.write();
                             order_write
                                 .payment_id
@@ -700,19 +697,16 @@ impl Solver {
                                 self.set_order_status(&mut order_write, SolverOrderStatus::Ready);
                             }
                         } else {
-                            tracing::warn!(
-                                "(solver) PreAuth approved handling failed: {}",
-                                payment_id
-                            )
+                            tracing::warn!(%payment_id, "PreAuth approved handling failed")
                         }
                     }
                     PreAuthStatus::NotEnoughFunds => {
                         tracing::warn!(
-                            "(solver) PreAuth failed: Not enough funds to pay [{}:{}] {} {:0.5}",
-                            chain_id,
-                            address,
-                            client_order_id,
-                            amount_payable
+                            %chain_id,
+                            %address,
+                            %client_order_id,
+                            %amount_payable,
+                            "PreAuth failed: Not enough funds to pay",
                         )
                     }
                 }
@@ -734,7 +728,7 @@ impl Solver {
                     );
 
                     if let Some(order) = order {
-                        tracing::info!("(solver) Payment authorized: {}", payment_id);
+                        tracing::info!(%payment_id, "Payment authorized");
                         let mut order_write = order.write();
                         self.chain_connector
                             .write()
@@ -765,19 +759,16 @@ impl Solver {
 
                         self.set_order_status(&mut order_write, SolverOrderStatus::Minted);
                     } else {
-                        tracing::warn!(
-                            "(solver) Payment authorized handling failed: {}",
-                            payment_id
-                        )
+                        tracing::warn!(%payment_id, "Payment authorized handling failed")
                     }
                 }
                 ConfirmStatus::NotEnoughFunds => {
                     tracing::warn!(
-                        "(solver) Payment failed: Not enough funds to pay [{}:{}] {} {}",
-                        chain_id,
-                        address,
-                        client_order_id,
-                        payment_id
+                        %chain_id,
+                        %address,
+                        %client_order_id,
+                        %payment_id,
+                        "Payment failed: Not enough funds to pay",
                     )
                 }
             },
@@ -798,11 +789,14 @@ impl Solver {
                 timestamp,
             } => {
                 tracing::info!(
-                    "(solver) Handle Index Order NewIndexOrder {} {} < {} from {}",
-                    symbol,
-                    client_order_id,
-                    client_order_id,
-                    address
+                    %chain_id,
+                    %address,
+                    %client_order_id,
+                    %symbol,
+                    ?side,
+                    %collateral_amount,
+                    %timestamp,
+                    "Handle Index Order NewIndexOrder",
                 );
                 self.client_orders.write().add_client_order(
                     chain_id,
@@ -818,13 +812,10 @@ impl Solver {
                 chain_id,
                 address,
                 client_order_id,
-                timestamp: _,
+                timestamp,
             } => {
-                tracing::info!(
-                    "(solver) Handle Cancel Index Order [{}:{}] {}",
-                    chain_id,
-                    address,
-                    client_order_id
+                tracing::info!(%chain_id, %address, %client_order_id, %timestamp,
+                    "Handle Cancel Index Order",
                 );
                 self.client_orders
                     .write()
@@ -835,14 +826,17 @@ impl Solver {
                 address,
                 client_order_id,
                 collateral_removed,
-                collateral_remaining: _,
+                collateral_remaining,
                 timestamp,
             } => {
                 tracing::info!(
-                    "(solver) Handle Index Order UpdateIndexOrder {} < {} from {}",
-                    client_order_id,
-                    client_order_id,
-                    address
+                    %chain_id,
+                    %address,
+                    %client_order_id,
+                    %collateral_removed,
+                    %collateral_remaining,
+                    %timestamp,
+                    "Handle Index Order UpdateIndexOrder",
                 );
                 self.client_orders.write().update_client_order(
                     chain_id,
@@ -867,16 +861,18 @@ impl Solver {
                 client_order_id,
                 collateral_remaining,
                 collateral_spent,
-                fees: _,
+                fees,
                 timestamp,
             } => {
                 tracing::info!(
-                    "(solver) Handle Index Order CollateralReady {} < {} from {}: {:0.5} {:0.5}",
-                    chain_id,
-                    client_order_id,
-                    address,
-                    collateral_remaining,
-                    collateral_spent
+                    %chain_id,
+                    %address,
+                    %client_order_id,
+                    %collateral_remaining,
+                    %collateral_spent,
+                    %fees,
+                    %timestamp,
+                    "Handle Index Order CollateralReady",
                 );
                 if let Some(order) =
                     self.client_orders
@@ -900,7 +896,7 @@ impl Solver {
                 } else {
                     // TODO: Tell CollateralManager that order is no longer
                     // Something needs to happen with collateral, e.g. reuse in next order
-                    Err(eyre!("(solver) Handle collateral ready ack: Missing order"))
+                    Err(eyre!("Handle collateral ready ack: Missing order"))
                 }
             }
         }
@@ -946,11 +942,9 @@ impl Solver {
                     %client_quote_id,
                     message = "Handle Cancel Quote Request"
                 );
-                self.client_quotes.write().cancel_client_quote(
-                    chain_id,
-                    address,
-                    client_quote_id,
-                )
+                self.client_quotes
+                    .write()
+                    .cancel_client_quote(chain_id, address, client_quote_id)
             }
         }
     }
@@ -967,19 +961,23 @@ impl Solver {
                 price,
                 quantity,
                 fee,
-                original_batch_quantity: _,
-                batch_quantity_remaining: _,
+                original_batch_quantity,
+                batch_quantity_remaining,
                 timestamp,
             } => {
                 tracing::info!(
-                    "(solver) Handle Inventory Event OpenLot {} {:?} {:5} {:0.5} @ {:0.5} + fee {:0.5} ({:0.3}%)",
-                    lot_id,
-                    side,
-                    symbol,
-                    quantity,
-                    price,
-                    fee,
-                    (|| safe!(safe!(fee * Amount::ONE_HUNDRED) / safe!(quantity * price)?))().unwrap_or_default()
+                    %order_id,
+                    %batch_order_id,
+                    %lot_id,
+                    %symbol,
+                    ?side,
+                    %price,
+                    %quantity,
+                    %fee,
+                    %original_batch_quantity,
+                    %batch_quantity_remaining,
+                    %timestamp,
+                    "Handle Inventory Event OpenLot",
                 );
                 self.batch_manager
                     .read()
@@ -999,36 +997,45 @@ impl Solver {
                     )
             }
             InventoryEvent::CloseLot {
-                original_order_id: _,
-                original_batch_order_id: _,
+                original_order_id,
+                original_batch_order_id,
                 original_lot_id,
                 closing_order_id,
                 closing_batch_order_id,
                 closing_lot_id,
                 symbol,
                 side,
-                original_price: _,
+                original_price,
                 closing_price,
                 closing_fee,
                 quantity_closed,
                 original_quantity,
                 quantity_remaining,
-                closing_batch_original_quantity: _,
-                closing_batch_quantity_remaining: _,
-                original_timestamp: _,
+                closing_batch_original_quantity,
+                closing_batch_quantity_remaining,
+                original_timestamp,
                 closing_timestamp,
             } => {
                 tracing::info!(
-                    "(solver) Handle Inventory Event CloseLot {} {} {:?} {:5} {:0.5}@{:0.5}+{:0.5} ({:0.5}%)",
-                    original_lot_id,
-                    closing_lot_id,
-                    side,
-                    symbol,
-                    quantity_closed,
-                    closing_price,
-                    closing_fee,
-                    (|| safe!(safe!(Amount::ONE_HUNDRED * safe!(original_quantity - quantity_remaining)?)?
-                        / original_quantity))().unwrap_or_default()
+                    %original_order_id,
+                    %original_batch_order_id,
+                    %original_lot_id,
+                    %closing_order_id,
+                    %closing_batch_order_id,
+                    %closing_lot_id,
+                    %symbol,
+                    ?side,
+                    %original_price,
+                    %closing_price,
+                    %closing_fee,
+                    %quantity_closed,
+                    %original_quantity,
+                    %quantity_remaining,
+                    %closing_batch_original_quantity,
+                    %closing_batch_quantity_remaining,
+                    %original_timestamp,
+                    %closing_timestamp,
+                    "Handle Inventory Event CloseLot",
                 );
                 self.batch_manager
                     .read()
@@ -1053,16 +1060,22 @@ impl Solver {
                 symbol,
                 side,
                 quantity_cancelled,
-                original_quantity: _,
-                quantity_remaining: _,
+                original_quantity,
+                quantity_remaining,
                 is_cancelled,
                 cancel_timestamp,
             } => {
                 tracing::info!(
-                    "(solver) Handle Inventory Event Cancel {} {} {}",
-                    order_id,
-                    batch_order_id,
-                    symbol
+                    %order_id,
+                    %batch_order_id,
+                    %symbol,
+                    ?side,
+                    %quantity_cancelled,
+                    %original_quantity,
+                    %quantity_remaining,
+                    %is_cancelled,
+                    %cancel_timestamp,
+                    "Handle Inventory Event Cancel",
                 );
                 self.batch_manager
                     .read()
@@ -1083,8 +1096,8 @@ impl Solver {
     /// receive current prices from Price Tracker
     pub fn handle_price_event(&self, notification: PriceEvent) {
         match notification {
-            PriceEvent::PriceChange { symbol } => {
-                //tracing::info!("(solver) Handle Price Event {:5}", symbol)
+            PriceEvent::PriceChange { symbol: _ } => {
+                // TODO: We could re-try orders with missing prices
             }
         };
     }
@@ -1092,11 +1105,11 @@ impl Solver {
     /// receive available liquidity from Order Book Manager
     pub fn handle_book_event(&self, notification: OrderBookEvent) {
         match notification {
-            OrderBookEvent::BookUpdate { symbol } => {
-                //tracing::info!("(solver) Handle Book Event {:5}", symbol);
+            OrderBookEvent::BookUpdate { symbol: _ } => {
+                // TODO: We could re-try orders with missing liquidity
             }
             OrderBookEvent::UpdateError { symbol, error } => {
-                //tracing::info!("(solver) Handle Book Event {:5}, Error: {}", symbol, error);
+                tracing::info!(%symbol, "Handle Book Error: {:?}", error);
             }
         }
     }
@@ -1106,7 +1119,7 @@ impl Solver {
         // TODO: (move this) once solvign is done notify new weights were applied
         match notification {
             BasketNotification::BasketAdded(symbol, basket) => {
-                tracing::info!("(solver) Handle Basket Notification BasketAdded {}", symbol);
+                tracing::info!(%symbol, "Handle Basket Notification BasketAdded");
                 self.chain_connector
                     .write()
                     .map_err(|e| eyre!("Failed to access chain connector {}", e))?
@@ -1125,10 +1138,7 @@ impl Solver {
                 Ok(())
             }
             BasketNotification::BasketUpdated(symbol, basket) => {
-                tracing::info!(
-                    "(solver) Handle Basket Notification BasketUpdated {}",
-                    symbol
-                );
+                tracing::info!(%symbol, "Handle Basket Notification BasketUpdated");
                 self.chain_connector
                     .write()
                     .map_err(|e| eyre!("Failed to access chain connector {}", e))?
@@ -1146,10 +1156,7 @@ impl Solver {
                 Ok(())
             }
             BasketNotification::BasketRemoved(symbol) => {
-                tracing::info!(
-                    "(solver) Handle Basket Notification BasketRemoved {}",
-                    symbol
-                );
+                tracing::info!(%symbol, "Handle Basket Notification BasketRemoved");
                 self.quote_request_manager
                     .write()
                     .map_err(|e| eyre!("Failed to access Quote Request manager {}", e))?
@@ -1168,18 +1175,18 @@ impl Solver {
 impl SetSolverOrderStatus for Solver {
     fn set_order_status(&self, order: &mut SolverOrder, status: SolverOrderStatus) {
         tracing::info!(
-            "(solver) Set Index Order Status: {} {:?}",
-            order.client_order_id,
-            status
+            client_order_id = %order.client_order_id,
+            ?status,
+            "Set Index Order Status",
         );
         order.status = status;
     }
 
     fn set_quote_status(&self, order: &mut SolverQuote, status: SolverQuoteStatus) {
         tracing::info!(
-            "(solver) Set Index Quote Status: {} {:?}",
-            order.client_quote_id,
-            status
+            client_quote_id = %order.client_quote_id,
+            ?status,
+            "Set Index Quote Status",
         );
         order.status = status;
     }

--- a/src/solver/solver_order.rs
+++ b/src/solver/solver_order.rs
@@ -307,7 +307,7 @@ impl SolverClientOrders {
                     // This is rather unexpected, as we would remove queue from map
                     // when it becomes empty.
                     tracing::warn!(
-                        "(solver) Cancel order found empty index order queue for the user"
+                        "Cancel order found empty index order queue for the user"
                     );
                     entry.remove();
                 }
@@ -316,7 +316,7 @@ impl SolverClientOrders {
             Entry::Vacant(_) => {
                 // This is rather unexpected, as we would add any new index orders to
                 // a queue and cancelling should always find a match in the queue.
-                tracing::warn!("(solver) Cancel order cannot find any index orders for the user");
+                tracing::warn!("Cancel order cannot find any index orders for the user");
                 false
             }
         };

--- a/src/solver/solver_quote.rs
+++ b/src/solver/solver_quote.rs
@@ -202,14 +202,14 @@ impl SolverClientQuotes {
                     }
                 } else {
                     tracing::warn!(
-                        "(solver) Cancel order found empty index order queue for the user"
+                        "Cancel order found empty index order queue for the user"
                     );
                     entry.remove();
                 }
                 notify
             }
             Entry::Vacant(_) => {
-                tracing::warn!("(solver) Cancel order cannot find any index orders for the user");
+                tracing::warn!("Cancel order cannot find any index orders for the user");
                 false
             }
         };

--- a/src/solver/solvers/simple_solver.rs
+++ b/src/solver/solvers/simple_solver.rs
@@ -415,7 +415,7 @@ impl SimpleSolver {
         tracing::info!(
             %client_order_id,
             %collateral_amount,
-            %order_upread.collateral_carried,
+            collateral_carried = %order_upread.collateral_carried,
             %collateral_available,
             %collateral_usable,
             %index_price,

--- a/src/solver/solvers/simple_solver.rs
+++ b/src/solver/solvers/simple_solver.rs
@@ -1477,7 +1477,7 @@ impl SolverStrategy for SimpleSolver {
 
             tracing::info!(
                 client_order_id = %engagement.client_order_id,
-                symbols = %engagement.symbol,
+                symbol = %engagement.symbol,
                 engaged_quantity = %engagement.engaged_quantity,
                 engaged_price = %engagement.engaged_price,
                 engaged_collateral = %engagement.engaged_collateral,

--- a/src/solver/solvers/simple_solver.rs
+++ b/src/solver/solvers/simple_solver.rs
@@ -15,8 +15,7 @@ use symm_core::core::{
     decimal_ext::DecimalExt,
     telemetry::TracingData,
 };
-use tracing::{span, trace_span, Level, Span};
-use tracing_opentelemetry::OpenTelemetrySpanExt;
+use tracing::{span, Level};
 
 use crate::{
     index::basket::Basket,
@@ -113,9 +112,9 @@ impl SimpleSolver {
             }
             Err(err) => {
                 tracing::warn!(
-                    "(simple-solver) Error while {} for IndexOrder {}: {:?}",
-                    error_action,
-                    order_upread.client_order_id,
+                    client_order_id = %order_upread.client_order_id,
+                    %error_action,
+                    "Failed to scan order batch: {:?}",
                     err
                 );
                 set_order_status(order_upread, error_status);
@@ -273,7 +272,7 @@ impl SimpleSolver {
             price_map = %json!(
                 get_prices.prices.iter().map(|(k, v)| (k, v)).collect::<HashMap<_, _>>()
             ),
-            message = "Asset Prices"
+            "Asset Prices"
         );
 
         let price_limits: HashMap<_, _> = get_prices
@@ -291,7 +290,7 @@ impl SimpleSolver {
             price_limit_map = %json!(
                 price_limits.iter().map(|(k, v)| (k, v)).collect::<HashMap<_, _>>()
             ),
-            message = "Asset Price Limits"
+            "Asset Price Limits"
         );
 
         Ok((price_limits, get_prices.missing_symbols))
@@ -317,11 +316,7 @@ impl SimpleSolver {
             if let (Some(price), Some(volley)) = (price, volley) {
                 basket_assets.push((ticker, price, quantity, volley));
             } else {
-                tracing::warn!(
-                    "(simple-solver) Basket Asset {}: ! x {} = !",
-                    ticker,
-                    quantity,
-                );
+                tracing::warn!(%ticker, %quantity, ?price, "Failed to compute volley");
             }
         }
         tracing::info!(
@@ -330,7 +325,7 @@ impl SimpleSolver {
             basket_map = %json!(
                 basket_assets.into_iter().map(|(t, p, q, v)| (t, [p, q, v])).collect::<HashMap<_, _>>()
             ),
-            message = "Index Price Limit"
+            "Index Price Limit"
         );
     }
 
@@ -365,11 +360,7 @@ impl SimpleSolver {
                         Either::Left((symbol, price))
                     }
                     Err(err) => {
-                        tracing::warn!(
-                            "(simple-solver) Failed to compute index price for {}: {:?}",
-                            symbol,
-                            err
-                        );
+                        tracing::warn!(%symbol, "Failed to compute index price: {:?}", err);
                         Either::Right(symbol)
                     }
                 },
@@ -422,15 +413,15 @@ impl SimpleSolver {
             .ok_or_eyre("Index order quantity computation error")?;
 
         tracing::info!(
-            "(simple-solver) Collateral to Quantity for Index Order: {} c={:0.5} cc={:0.5} ca={:0.5} cu={:0.5} p={:0.5} q={:0.5} ff={:0.5}",
-            client_order_id,
-            collateral_amount,
-            order_upread.collateral_carried,
-            collateral_available,
-            collateral_usable,
-            index_price,
-            index_order_quantity,
-            self.fee_factor
+            %client_order_id,
+            %collateral_amount,
+            %order_upread.collateral_carried,
+            %collateral_available,
+            %collateral_usable,
+            %index_price,
+            %index_order_quantity,
+            fee_factor = %self.fee_factor,
+            "Computed Index Order quantity from collateral"
         );
 
         let asset_quantities: HashMap<_, _> = basket
@@ -440,12 +431,12 @@ impl SimpleSolver {
                 let asset_symbol = &basket_asset.weight.asset.ticker;
                 let asset_quantity = safe!(basket_asset.quantity * index_order_quantity)?;
                 tracing::info!(
-                    "(simple-solver) Asset Quantity for Index Order: {} {} q={:0.5} baq={:0.5} oq={:0.5}",
-                    client_order_id,
-                    asset_symbol,
-                    asset_quantity,
-                    basket_asset.quantity,
-                    index_order_quantity
+                    %client_order_id,
+                    %asset_symbol,
+                    %asset_quantity,
+                    %basket_asset.quantity,
+                    %index_order_quantity,
+                    "Computed Asset Order quantity for Index Order"
                 );
                 Some((asset_symbol.clone(), asset_quantity))
             })
@@ -481,12 +472,8 @@ impl SimpleSolver {
         let capped_order_quantity = safe!(order_quantity * volley_fraction)
             .ok_or_eyre("Cannot calculate capped order quantity")?;
 
-        tracing::info!(
-            "(simple-solver) Capping Volley Size for Index Order: {} oq={:0.5} coq={:0.5}",
-            client_order_id,
-            order_quantity,
-            capped_order_quantity
-        );
+        tracing::info!(%client_order_id, %order_quantity, %capped_order_quantity,
+            "Capping volley size for Index Order");
 
         let mut capped_asset_quantities = HashMap::new();
 
@@ -497,12 +484,8 @@ impl SimpleSolver {
 
             capped_asset_quantities.insert(asset_symbol.clone(), capped_asset_quantity);
 
-            tracing::info!(
-                "(simple-solver) Capping Volley Size for Asset: {} aq={:0.5} caq={:0.5}",
-                asset_symbol,
-                asset_quantity,
-                capped_asset_quantity
-            );
+            tracing::info!(%asset_symbol, %asset_quantity, %capped_asset_quantity,
+                "Capping volley size for Asset");
         }
 
         Ok((capped_order_quantity, capped_asset_quantities))
@@ -694,15 +677,15 @@ impl SimpleSolver {
             fitting_order_quantity = fitting_order_quantity.min(possible_order_quantity);
 
             tracing::info!(
-                "(simple-solver) Fitting Quantity for Index Order: {} {} {:0.5} tal={:0.5} taq={:0.5} acf={:0.5} alc={:0.5} poq={:0.5}",
-                client_order_id,
-                asset_symbol,
-                fitting_order_quantity,
-                total_asset_liquidity,
-                total_asset_quantity,
-                asset_contribution_fraction,
-                asset_liquidity_contribution,
-                possible_order_quantity
+                %client_order_id,
+                %asset_symbol,
+                %fitting_order_quantity,
+                %total_asset_liquidity,
+                %total_asset_quantity,
+                %asset_contribution_fraction,
+                %asset_liquidity_contribution,
+                %possible_order_quantity,
+                "Computed Index Order quantity fitting into liquidity"
             );
         }
 
@@ -808,11 +791,11 @@ impl SimpleSolver {
             asset_contribution_fractions.insert(asset_symbol.clone(), asset_contribution_fraction);
 
             tracing::info!(
-                "(simple-solver) Asset Fractions for Index Order: {} {} taq={:0.5} acf={:0.5}",
-                client_order_id,
-                asset_symbol,
-                total_asset_quantity,
-                asset_contribution_fraction,
+                %client_order_id,
+                %asset_symbol,
+                %total_asset_quantity,
+                %asset_contribution_fraction,
+                "Computed Asset contribution fractions for Index Order",
             );
         }
 
@@ -909,13 +892,13 @@ impl SimpleSolver {
                 .ok_or_else(|| eyre!("Cannot calculate quantity extra for an asset {}", symbol))?;
 
             tracing::info!(
-                "(simple-solver) Padding {}: {} => {}, {} => {} (+{})",
-                symbol,
-                asset_volley_size,
-                volley_size,
-                asset_quantity,
-                quantity,
-                quantity_extra
+                %symbol,
+                %asset_volley_size,
+                %volley_size,
+                %asset_quantity,
+                %quantity,
+                %quantity_extra,
+                "Computed padding for Asset Order",
             );
 
             padded_asset_quantites
@@ -1493,12 +1476,12 @@ impl SolverStrategy for SimpleSolver {
             };
 
             tracing::info!(
-                "(simple-solver) Solver Order Engagement: {} {} eq={:0.5} ep={:0.5} ec={:0.5}",
-                engagement.client_order_id,
-                engagement.symbol,
-                engagement.engaged_quantity,
-                engagement.engaged_price,
-                engagement.engaged_collateral
+                client_order_id = %engagement.client_order_id,
+                symbols = %engagement.symbol,
+                engaged_quantity = %engagement.engaged_quantity,
+                engaged_price = %engagement.engaged_price,
+                engaged_collateral = %engagement.engaged_collateral,
+                "Solver Order Engagement"
             );
 
             engagenments.engaged_orders.push(engagement);


### PR DESCRIPTION
Use structural event such as:
```
tracing::info!(%chain_id, %address, %client_order_id, "Some message");
```

instead of formatted string like:
```
tracing::info!("Some message [{}:{}] {}", chain_id, address, client_order_id);
```

When events are sent in structural format, then we're able to analyse them in Kibana.

The drawback here is that logs printed to stdout aren't so readable anymore. Having readable logs on stdout was important in the initial phase of development. When deploying to production we need to use tools like Kibana to be able to see all the traces from production traffic.
