### PR TITLE
Fixes: Mint invoice details

### DIFF
--- a/deploy_templates/docker-compose.prod.yaml.template
+++ b/deploy_templates/docker-compose.prod.yaml.template
@@ -12,12 +12,12 @@ services:
               "-c", "configs", 
               "--otlp-trace-url", "http://otel-collector:4318/v1/traces", 
               "--otlp-log-url", "http://otel-collector:4318/v1/logs", 
-              "--batch-size", "4",
+              "--batch-size", "50",
               "--simulate-sender",
               "fix-server", "1000000"]
 
     environment:
-      RUST_LOG: debug,binance_sdk=off,hyper=off
+      RUST_LOG: info,binance_sdk=off,hyper=off
     
     depends_on:
       otel-collector:

--- a/deploy_templates/otel-collector-config.prod.yaml.template
+++ b/deploy_templates/otel-collector-config.prod.yaml.template
@@ -6,8 +6,8 @@ receivers:
 
 processors:
   batch:
-    send_batch_size: 4
-    timeout: 1s
+    send_batch_size: 100
+    timeout: 10s
 
 exporters:
   otlp/elastic:
@@ -24,12 +24,12 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [otlp/elastic,debug]
+      exporters: [otlp/elastic]
 
     logs:
       receivers: [otlp]
       processors: [batch]
-      exporters: [otlp/elastic,debug]
+      exporters: [otlp/elastic]
 
     metrics:
       receivers: [otlp]

--- a/src/solver/batch_manager.rs
+++ b/src/solver/batch_manager.rs
@@ -919,18 +919,6 @@ impl BatchManager {
             }
         }
 
-        host.fill_order_request(
-            index_order_write.chain_id,
-            &index_order_write.address,
-            &index_order_write.client_order_id,
-            &index_order_write.symbol,
-            collateral_spent,
-            filled_quantity_delta,
-            order_fill_rate,
-            index_order_write.status,
-            batch.last_update_timestamp,
-        )?;
-
         if self.fill_threshold < order_fill_rate {
             tracing::info!(
                 chain_id = %index_order_write.chain_id,

--- a/src/solver/index_order_manager.rs
+++ b/src/solver/index_order_manager.rs
@@ -767,12 +767,14 @@ impl IndexOrderManager {
                 update.filled_quantity = update_filled_quantity;
                 update.collateral_spent = update_collateral_spent;
                 update.engaged_collateral = update_engaged_collateral;
+                update.timestamp = timestamp;
             });
 
             index_order.with_upgraded(|index_order| {
                 index_order.filled_quantity = index_order_filled_quantity;
                 index_order.collateral_spent = index_order_collateral_spent;
                 index_order.engaged_collateral = index_order_engaged_collateral;
+                index_order.last_update_timestamp = timestamp;
             });
 
             let status_string = match status {

--- a/src/solver/solver.rs
+++ b/src/solver/solver.rs
@@ -517,8 +517,8 @@ impl Solver {
             .lots
             .iter()
             .try_fold(Amount::ZERO, |cost, lot| {
-                let lot_value = safe! {lot.price * lot.quantity}?;
-                let cost = safe! {lot_value + lot.fee + cost}?;
+                let lot_value = safe! {lot.price * lot.assigned_quantity}?;
+                let cost = safe! {lot_value + lot.assigned_fee + cost}?;
                 Some(cost)
             })
             .ok_or_eyre("Math Problem")?;

--- a/src/solver/solver_order.rs
+++ b/src/solver/solver_order.rs
@@ -110,19 +110,31 @@ pub struct SolverOrderAssetLot {
     /// Symbol of an asset
     pub symbol: Symbol,
 
-    /// Quantity allocated to index order
-    pub quantity: Amount,
-
     /// Executed price
     pub price: Amount,
 
-    /// Execution fee
-    pub fee: Amount,
+    /// Original quantity
+    pub original_quantity: Amount,
+
+    /// Original execution fee
+    pub original_fee: Amount,
+
+    /// Quantity allocated to index order
+    pub assigned_quantity: Amount,
+    
+    /// Execution fee allocated to index order
+    pub assigned_fee: Amount,
+
+    /// Time when lot was created
+    pub created_timestamp: DateTime<Utc>,
+
+    /// Time when lot was assigned to index order
+    pub assigned_timestamp: DateTime<Utc>,
 }
 
 impl SolverOrderAssetLot {
     pub fn compute_collateral_spent(&self) -> Option<Amount> {
-        safe!(safe!(self.quantity * self.price) + self.fee)
+        safe!(safe!(self.assigned_quantity * self.price) + self.assigned_fee)
     }
 }
 


### PR DESCRIPTION
- [x] Amount Paid is the total amount that we took from the collateral including all transaction charges and fees
- [x] More detail in assigned lots including original quantity, original fee, created timestamp, and renamed other fields to assigned quantity, assigned fee, assigned timestamp

This allows for more intuitive understanding of MintInvoice details as well as it allows us to validate which lots were used, when they were created with what quantity, and how much of that quantity was assigned to the index order when when.