### PR TITLE
Tracker: added 0-10 band, lower-saturate to 0, docker templates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6818,6 +6818,7 @@ dependencies = [
  "index-maker",
  "itertools 0.14.0",
  "market-data",
+ "openssl",
  "parking_lot 0.12.4",
  "rust_decimal",
  "rust_decimal_macros",

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,9 @@ COPY . .
 # Build the final release binary for the musl target
 RUN cargo build --release --target=x86_64-unknown-linux-musl --features alpine-deploy
 
+# Build tracker
+RUN cargo build --release -p tracker --target=x86_64-unknown-linux-musl --features alpine-deploy
+
 # Stage 2: Create the final, minimal runtime image
 FROM --platform=linux/amd64 alpine:3.22
 
@@ -22,6 +25,7 @@ WORKDIR /app
 RUN apk add --no-cache ca-certificates
 
 COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/index-maker ./
+COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/tracker ./
 COPY --from=builder /app/configs ./configs
 COPY --from=builder /app/indexes ./indexes
 

--- a/apps/tracker/Cargo.toml
+++ b/apps/tracker/Cargo.toml
@@ -3,15 +3,19 @@ name = "tracker"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+alpine-deploy = ["openssl/vendored"]
+
 [dependencies]
 binance-market-data = { workspace = true }
-clap = { workspace = true }
 chrono = { workspace = true }
+clap = { workspace = true }
 csv = { workspace = true }
 eyre = { workspace = true }
 index-maker = { workspace = true }
 itertools = { workspace = true }
 market-data = { workspace = true }
+openssl = { workspace = true, optional = true }
 parking_lot = { workspace = true }
 rust_decimal = { workspace = true }
 rust_decimal_macros = { workspace = true }

--- a/apps/tracker/src/main.rs
+++ b/apps/tracker/src/main.rs
@@ -10,7 +10,7 @@ use itertools::Itertools;
 use rust_decimal::dec;
 use symm_core::{
     core::{
-        async_loop::AsyncLoop, bits::Symbol, functional::IntoObservableManyArc, logging::log_init,
+        async_loop::AsyncLoop, bits::{Amount, Symbol}, functional::IntoObservableManyArc, logging::log_init,
     },
     init_log,
     market_data::market_data_connector::{MarketDataEvent, Subscription},
@@ -155,9 +155,10 @@ async fn main() {
         book_manager,
         symbols,
         vec![
-            "10", "20", "30", "40", "50", "75", "100", "150", "200", "300", "400", "500",
+            "0", "10", "20", "30", "40", "50", "75", "100", "150", "200", "300", "400", "500",
         ],
         vec![
+            Amount::ZERO,
             dec!(0.001),
             dec!(0.002),
             dec!(0.003),

--- a/deploy_templates/docker-compose.prod.yaml
+++ b/deploy_templates/docker-compose.prod.yaml
@@ -1,7 +1,7 @@
 version: '3.8'
 
 services:
-  quote-server:
+  index-maker-issuer:
     platform: linux/amd64
     image: ${DOCKER_IMAGE_NAME}
     ports:
@@ -26,14 +26,30 @@ services:
 
     restart: unless-stopped
 
+  index-maker-tracker:
+    platform: linux/amd64
+    image: ${DOCKER_IMAGE_NAME}
+    ports: []
+
+    command: ["./tracker", "-i", "300", "-d", "1440", "-m", "flat" ]
+
+    environment:
+      RUST_LOG: ${RUST_LOG}
+    
+    volumes:
+      - ./hourly_batches:/app/hourly_batches
+    
+    depends_on:
+      otel-collector:
+        condition: service_started
+
   otel-collector:
     build:
       context: .
       dockerfile: Dockerfile.otlp.prod
     container_name: otel-collector
     ports:
-      - "4318:4318" # OTLP HTTP receiver
-      # - "4317:4317" # OTLP gRPC receiver
+      - "4318:4318"
     command:
       - --config=/etc/otelcol-contrib/config.yaml
     restart: unless-stopped

--- a/deploy_templates/service-logs.sh.template
+++ b/deploy_templates/service-logs.sh.template
@@ -3,4 +3,4 @@
 . ~/.index_maker
 export DOCKER_IMAGE_NAME="<DOCKER_IMAGE_NAME>"
 
-docker-compose -f docker-compose.prod.yaml logs -f quote-server
+docker-compose -f docker-compose.prod.yaml logs -f $@


### PR DESCRIPTION
- [x] Renamed main service to `index-maker-issuer`
- [x] Added `index-maker-tracker` service
- [x] Tracker: added 0-10 bands
- [x] Tracker: saturate to 0 when subtracting high - low for differencial band (*)

(*) When we collect liquidity we get absolute value in range [0..threshold], and to obtain liquidity in range [Lo..Hi] we subtract liquidity at Lo from liquidity at Hi. There can be only two possible reasons why we would get negative value:
1. we didn't get Lo and Hi while holding same lock - this used to be the case, now we use single lock to get all liquidity
2. prcecision issue - we saturate to 0 to ensure that number won't be negative in that case
