### PR TITLE
 Route collateral from separate source for each Index #163

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,9 +957,10 @@ name = "anvil_orchestrator"
 version = "0.1.0"
 dependencies = [
  "alloy",
- "alloy-evm-connector",
- "anyhow",
+ "alloy-chain-connector",
+ "eyre",
  "hex",
+ "otc-custody",
  "reqwest 0.11.27",
  "rust_decimal",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,3 +163,4 @@ tracing = "0.1"
 tracing-appender = "0.2.3"
 tracing-opentelemetry = "0.31.0"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "registry"] }
+dotenvy = "0.15"

--- a/apps/anvil_orchestrator/Cargo.toml
+++ b/apps/anvil_orchestrator/Cargo.toml
@@ -5,13 +5,14 @@ edition = "2021"
 
 [dependencies]
 alloy = { workspace = true }
-alloy-evm-connector = { workspace = true }
-tokio = { workspace = true }
+alloy-chain-connector = { workspace = true }
+eyre = { workspace = true }
+hex = { workspace = true }
+otc-custody = { workspace = true }
 reqwest = { workspace = true }
+rust_decimal = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-rust_decimal = { workspace = true }
-hex = { workspace = true }
-anyhow = "1"

--- a/apps/anvil_orchestrator/src/main.rs
+++ b/apps/anvil_orchestrator/src/main.rs
@@ -1,9 +1,8 @@
-use alloy_evm_connector::{contracts::ERC20, IntoAmount};
-use anyhow::{anyhow, Context, Result};
-use rust_decimal::Decimal;
+use alloy_chain_connector::util::amount_converter::AmountConverter;
+use eyre::{eyre, Context, Result};
+use otc_custody::contracts::ERC20;
 use serde_json::json;
 use std::{
-    path::PathBuf,
     process::{Command, Stdio},
     time::Duration,
 };
@@ -15,40 +14,26 @@ use alloy::{
     network::{EthereumWallet, TransactionBuilder},
     primitives::{address, Address, Bytes, U256},
     providers::{Provider, ProviderBuilder},
-    rpc::types::{TransactionInput, TransactionRequest},
+    rpc::types::TransactionRequest,
     signers::local::PrivateKeySigner,
-    sol,
     sol_types::SolCall,
 };
-sol! {
-    interface IERC20 {
-        function transfer(address to, uint256 amount) external returns (bool);
-    }
-}
-sol! {
-    interface IERC20View {
-        function balanceOf(address account) external view returns (uint256);
-        function decimals() external view returns (uint8);
-        function symbol() external view returns (string);
-    }
-}
 
-pub async fn erc20_balance_of<P: Provider>(
-    provider: &P,
-    token: Address,
-    account: Address,
-) -> anyhow::Result<U256> {
-    let data: Bytes = IERC20View::balanceOfCall { account }.abi_encode().into();
-    let call_tx = TransactionRequest::default()
-        .with_to(token)
-        .with_input(data);
-    let out = provider.call(call_tx).await?; // raw Bytes
-    let b = &out[out.len().saturating_sub(32)..]; // last 32 bytes
-    Ok(U256::from_be_slice(b))
+async fn temp_foo() -> Result<()> {
+    let provider = ProviderBuilder::new()
+        .connect("http://127.0.0.1:8545")
+        .await
+        .unwrap();
+
+    let usdc_address = address!("0xaf88d065e77c8cC2239327C5EDb3A432268e5831");
+    let usdc_contract = ERC20::new(usdc_address, provider);
+
+    let decimals = usdc_contract.decimals().call().await.unwrap();
+
+    println!("USDC DECIMALS: {}", decimals);
+
+    Ok(())
 }
-const DEFAULT_FOUNDRY_ROOT: &str = "apps/anvil_orchestrator";
-const SRC_DIR_NAME: &str = "contract"; // <— singular, per your layout
-const CONTRACT_FILE: &str = "DepositEmitter.sol";
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -110,6 +95,9 @@ async fn main() -> Result<()> {
 
     // Wait for RPC to be up
     wait_for_rpc(&rpc_url).await?;
+    
+    temp_foo().await.unwrap();
+
 
     // ----------------- 2) Build contract with forge -------------
     info!("Building DepositEmitter with forge …");
@@ -129,7 +117,8 @@ async fn main() -> Result<()> {
     info!("✅ Setup complete. Anvil is running at {rpc_url}.");
 
     let provider = ProviderBuilder::new().connect(&rpc_url).await?;
-    let bal = erc20_balance_of(&provider, usdc, recipients[0]).await?;
+    let usdc_contract = ERC20::new(usdc, &provider);
+    let bal = usdc_contract.balanceOf(recipients[0]).call().await?;
     println!("acct0 USDC: {} (raw)", bal);
     println!("acct0 USDC: {} (USDC)", bal / U256::from(1_000_000u64));
 
@@ -140,7 +129,7 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-async fn top_up_eth(rpc_url: &str, addr: Address, eth: u64) -> anyhow::Result<()> {
+async fn top_up_eth(rpc_url: &str, addr: Address, eth: u64) -> eyre::Result<()> {
     // 1 ETH = 10^18 wei
     let wei_per_eth: U256 = U256::from(1_000_000_000_000_000_000u128);
     let wei: U256 = U256::from(eth) * wei_per_eth;
@@ -171,7 +160,7 @@ async fn wait_for_rpc(rpc: &str) -> Result<()> {
         }
         sleep(Duration::from_millis(500)).await;
     }
-    Err(anyhow!("Timed out waiting for Anvil JSON-RPC at {rpc}"))
+    Err(eyre!("Timed out waiting for Anvil JSON-RPC at {rpc}"))
 }
 
 fn run_cmd(bin: &str, args: &[&str]) -> Result<()> {
@@ -180,7 +169,7 @@ fn run_cmd(bin: &str, args: &[&str]) -> Result<()> {
         .status()
         .with_context(|| format!("Failed to run {bin}"))?;
     if !status.success() {
-        return Err(anyhow!("{bin} {:?} exited with {status}", args));
+        return Err(eyre!("{bin} {:?} exited with {status}", args));
     }
     Ok(())
 }
@@ -190,7 +179,7 @@ fn read_bytecode(artifact_path: &str) -> Result<Vec<u8>> {
     let v: serde_json::Value = serde_json::from_str(&text)?;
     let obj = v["bytecode"]["object"]
         .as_str()
-        .ok_or_else(|| anyhow!("bytecode.object missing in artifact"))?;
+        .ok_or_else(|| eyre!("bytecode.object missing in artifact"))?;
     let obj_clean = obj.trim_start_matches("0x");
     Ok(hex::decode(obj_clean)?)
 }
@@ -218,7 +207,7 @@ async fn deploy_contract(
     let receipt = pending.get_receipt().await?;
     let deployed = receipt
         .contract_address
-        .ok_or_else(|| anyhow!("No contract address in receipt"))?;
+        .ok_or_else(|| eyre!("No contract address in receipt"))?;
     Ok(deployed)
 }
 
@@ -249,11 +238,15 @@ async fn fund_usdc_to_accounts(
     // 2) provider WITHOUT wallet (node accepts txs from impersonated addr)
     let provider = ProviderBuilder::new().connect(rpc_url).await?;
 
+    println!("RPC URL: {}", rpc_url);
+    println!("Whale address: {}", whale);
+    println!("USDC contract address: {}", usdc);
     let usdc_contract_whale = ERC20::new(usdc, &provider);
+    let usdc_converter = AmountConverter::new(usdc_contract_whale.decimals().call().await?);
 
-    let whale_balance = usdc_contract_whale.balanceOf(whale).call().await.unwrap();
-    let whale_balance_usdc = whale_balance.into_amount_usdc().unwrap();
-    let amount_usdc = amount.into_amount_usdc().unwrap();
+    let whale_balance = usdc_contract_whale.balanceOf(whale).call().await?;
+    let whale_balance_usdc = usdc_converter.into_amount(whale_balance)?;
+    let amount_usdc = usdc_converter.into_amount(amount)?;
 
     tracing::info!(
         "Whale USDC balance: {} USDC, Amount to transfer: {} USDC, Whale address: {}, USDC address: {}",
@@ -269,7 +262,7 @@ async fn fund_usdc_to_accounts(
 
     // 3) transfer USDC for each recipient
     for &to in recipients {
-        let call = IERC20::transferCall { to, amount }.abi_encode();
+        let call = ERC20::transferCall { to, amount }.abi_encode();
         let input: Bytes = Bytes::from(call);
 
         let tx = TransactionRequest::default()
@@ -282,7 +275,7 @@ async fn fund_usdc_to_accounts(
         let receipt = pending.get_receipt().await?;
         if !receipt.status() {
             error!("USDC transfer to {to:#x} failed: {:?}", receipt);
-            return Err(anyhow!("USDC transfer failed"));
+            return Err(eyre!("USDC transfer failed"));
         }
         info!(
             "{amount} USDC -> {to:#x} | tx {:?}",
@@ -308,25 +301,25 @@ async fn fund_usdc_to_accounts(
 fn parse_units(amount: &str, decimals: u32) -> Result<U256> {
     let s = amount.trim();
     if s.is_empty() {
-        return Err(anyhow!("empty amount"));
+        return Err(eyre!("empty amount"));
     }
     if s.starts_with('-') {
-        return Err(anyhow!("amount must be positive"));
+        return Err(eyre!("amount must be positive"));
     }
     let mut parts = s.split('.');
     let int_part = parts.next().unwrap_or("0");
     let frac_part = parts.next().unwrap_or("");
     if parts.next().is_some() {
-        return Err(anyhow!("invalid number (multiple '.')"));
+        return Err(eyre!("invalid number (multiple '.')"));
     }
     if !int_part.chars().all(|c| c.is_ascii_digit()) {
-        return Err(anyhow!("invalid integer part"));
+        return Err(eyre!("invalid integer part"));
     }
     if !frac_part.chars().all(|c| c.is_ascii_digit()) {
-        return Err(anyhow!("invalid fractional part"));
+        return Err(eyre!("invalid fractional part"));
     }
     if frac_part.len() > decimals as usize {
-        return Err(anyhow!("too many decimal places (max {decimals})"));
+        return Err(eyre!("too many decimal places (max {decimals})"));
     }
 
     // strip leading zeros in integer part
@@ -348,6 +341,6 @@ fn parse_units(amount: &str, decimals: u32) -> Result<U256> {
         combined
     };
 
-    let value: U256 = combined.parse().map_err(|e| anyhow!("parse U256: {e:?}"))?;
+    let value: U256 = combined.parse().map_err(|e| eyre!("parse U256: {e:?}"))?;
     Ok(value)
 }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -19,10 +19,10 @@ binance-sdk = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
 crossbeam = { workspace = true }
-dotenvy = "0.15"
+dotenvy = { workspace = true }
 eyre = { workspace = true }
 futures-util = { workspace = true }
-hex = "0.4"
+hex = { workspace = true }
 index-core = { workspace = true }
 index-maker = { workspace = true }
 itertools = { workspace = true }

--- a/libs/index-core/src/collateral/collateral_router.rs
+++ b/libs/index-core/src/collateral/collateral_router.rs
@@ -117,7 +117,7 @@ pub struct CollateralRouter {
     observer: SingleObserver<CollateralTransferEvent>,
     bridges: HashMap<(Symbol, Symbol), Arc<ComponentLock<dyn CollateralBridge>>>,
     routes: Vec<Vec<Symbol>>,
-    chain_sources: HashMap<u32, Symbol>,
+    chain_sources: HashMap<(u32, Symbol), Symbol>,
     default_destination: Option<Symbol>,
 }
 
@@ -169,10 +169,11 @@ impl CollateralRouter {
     pub fn add_chain_source(
         &mut self,
         chain_id: u32,
+        symbol: Symbol,
         collateral_designation: Symbol,
     ) -> Result<()> {
         self.chain_sources
-            .insert(chain_id, collateral_designation)
+            .insert((chain_id, symbol), collateral_designation)
             .is_none()
             .then_some(())
             .ok_or_eyre("Duplicate chain ID")
@@ -191,6 +192,7 @@ impl CollateralRouter {
         chain_id: u32,
         address: Address,
         client_order_id: ClientOrderId,
+        symbol: Symbol,
         side: Side,
         amount: Amount,
     ) -> Result<()> {
@@ -207,7 +209,7 @@ impl CollateralRouter {
 
         let transfer_from = self
             .chain_sources
-            .get(&chain_id)
+            .get(&(chain_id, symbol))
             .ok_or_eyre("Failed to find source")?;
 
         let transfer_to = self
@@ -355,6 +357,7 @@ pub mod test_util {
             IntoObservableSingle, IntoObservableSingleVTable, NotificationHandlerOnce,
             PublishSingle, SingleObserver,
         },
+        test_util::{get_mock_index_name_1, get_mock_index_name_2, get_mock_index_name_3},
     };
 
     use super::{CollateralBridge, CollateralDesignation, CollateralRouter, CollateralRouterEvent};
@@ -616,12 +619,20 @@ pub mod test_util {
             implement_mock_bridge(tx, bridge, &router, &calculate_fee);
         }
 
+        let index_symbols = vec![
+            get_mock_index_name_1(),
+            get_mock_index_name_2(),
+            get_mock_index_name_3(),
+        ];
+
         for (chain_id, source) in source_chain_map {
-            router
-                .write()
-                .unwrap()
-                .add_chain_source(*chain_id, source.to_owned().into())
-                .unwrap();
+            for symbol in &index_symbols {
+                router
+                    .write()
+                    .unwrap()
+                    .add_chain_source(*chain_id, symbol.clone(), source.to_owned().into())
+                    .unwrap();
+            }
         }
 
         router
@@ -656,8 +667,7 @@ mod test {
             bits::Side,
             functional::IntoObservableSingle,
             test_util::{
-                flag_mock_atomic_bool, get_mock_address_1, get_mock_atomic_bool_pair,
-                get_mock_defer_channel, run_mock_deferred, test_mock_atomic_bool,
+                flag_mock_atomic_bool, get_mock_address_1, get_mock_atomic_bool_pair, get_mock_defer_channel, get_mock_index_name_1, run_mock_deferred, test_mock_atomic_bool
             },
         },
     };
@@ -741,6 +751,7 @@ mod test {
                 expected_chain_id,
                 get_mock_address_1(),
                 "C-1".into(),
+                get_mock_index_name_1(),
                 Side::Buy,
                 dec!(1000.0),
             )

--- a/libs/otc-custody/src/contracts.rs
+++ b/libs/otc-custody/src/contracts.rs
@@ -3,15 +3,14 @@ use alloy::sol;
 sol! {
     #[sol(rpc)]
     contract ERC20 {
-
         function approve(address spender, uint256 amount) external returns (bool);
-        
         function allowance(address owner, address spender) external view returns (uint256);
-        
         function transferFrom(address from, address to, uint256 amount) external returns (bool);
         function balanceOf(address account) external view returns (uint256);
         function transfer(address to, uint256 amount) external returns (bool);
         function decimals() external view returns (uint8);
+        function name() external view returns (string memory);
+        function symbol() external view returns (string memory);
     }
 
     #[sol(rpc)]

--- a/src/app/chain_connector.rs
+++ b/src/app/chain_connector.rs
@@ -37,6 +37,9 @@ pub struct RealChainConnectorConfig {
     #[builder(setter(into, strip_option), default)]
     pub with_router: Option<CollateralRouterConfig>,
 
+    #[builder(setter(into, strip_option), default)]
+    pub index_symbols: Vec<Symbol>, // TODO: use Vec<otc_custody::index::IndexInstance> instead
+
     #[builder(setter(skip))]
     chain_connector: Option<Arc<ComponentLock<RealChainConnector>>>,
 }
@@ -191,7 +194,7 @@ impl RealChainConnectorConfigBuilder {
             //    let bridge_to_binance = Arc::new(std::sync::RwLock::new(
             //        OTCCustodyToWalletCollateralBridge::new(index_custody, binance_wallet),
             //    ));
-            
+
             //    router_write.add_bridge(bridge_to_binance)?;
             //    router_write.add_route(&[index_custody_name.clone(), binance_wallet_name.clone()])?;
 
@@ -246,8 +249,14 @@ impl RealChainConnectorConfigBuilder {
             // Configure possible routes
             router_write.add_route(&[src_custody_name.clone(), dst_custody_name.clone()])?;
 
-            // Map incoming chain to source custody
-            router_write.add_chain_source(chain_id, src_custody_name)?;
+            for symbol in &config.index_symbols {
+                // Map incoming chain to source custody
+                router_write.add_chain_source(
+                    chain_id,
+                    symbol.clone(),
+                    src_custody_name.clone(),
+                )?;
+            }
 
             // Tell final destination custody
             router_write.set_default_destination(dst_custody_name)?;

--- a/src/collateral/collateral_manager.rs
+++ b/src/collateral/collateral_manager.rs
@@ -164,6 +164,7 @@ impl CollateralManager {
                             request.chain_id,
                             request.address,
                             request.client_order_id.clone(),
+                            request.symbol.clone(),
                             request.side,
                             request.collateral_amount,
                         )
@@ -468,9 +469,7 @@ mod test {
             functional::IntoObservableSingle,
             telemetry::TracingData,
             test_util::{
-                flag_mock_atomic_bool, get_mock_address_1, get_mock_asset_name_1,
-                get_mock_asset_name_2, get_mock_atomic_bool_pair, get_mock_defer_channel,
-                run_mock_deferred, test_mock_atomic_bool,
+                flag_mock_atomic_bool, get_mock_address_1, get_mock_asset_name_1, get_mock_asset_name_2, get_mock_atomic_bool_pair, get_mock_defer_channel, get_mock_index_name_1, run_mock_deferred, test_mock_atomic_bool
             },
         },
     };
@@ -627,6 +626,7 @@ mod test {
             chain_id: 1,
             address: get_mock_address_1(),
             client_order_id: "C-1".into(),
+            symbol: get_mock_index_name_1(),
             side: Side::Buy,
             collateral_amount: dec!(1000.0),
             asset_requirements: HashMap::from([

--- a/src/main.rs
+++ b/src/main.rs
@@ -226,6 +226,7 @@ impl ChainMode {
     fn new_with_router(
         simulate_chain: bool,
         main_quote_currency: Symbol,
+        index_symbols: Vec<Symbol>,
         router_config: &CollateralRouterConfig,
     ) -> Self {
         if simulate_chain {
@@ -237,6 +238,7 @@ impl ChainMode {
                 .chain_id(1u32)
                 .source(format!("SRC:BINANCE:{}", main_quote_currency))
                 .destination(format!("DST:BINANCE:{}", main_quote_currency))
+                .index_symbols(index_symbols)
                 .with_router(router_config.clone())
                 .build()
                 .expect("Failed to build collateral router");
@@ -247,6 +249,7 @@ impl ChainMode {
         } else {
             let evm_connector_config = RealChainConnectorConfig::builder()
                 .with_router(router_config.clone())
+                .index_symbols(index_symbols)
                 .build_arc()
                 .expect("Failed to build evm chain connector");
 
@@ -405,8 +408,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .build()
         .expect("Failed to build collateral router");
 
-    let chain_mode =
-        ChainMode::new_with_router(cli.simulate_chain, main_quote_currency, &router_config);
+    // TODO: Please, unhardcode me!
+    let index_symbols = vec![
+        Symbol::from("SO2"),
+        Symbol::from("SO3"),
+        Symbol::from("SY100"),
+    ];
+
+    let chain_mode = ChainMode::new_with_router(
+        cli.simulate_chain,
+        main_quote_currency,
+        index_symbols,
+        &router_config,
+    );
 
     // ==== Real stuff
     // ----

--- a/src/solver/solver.rs
+++ b/src/solver/solver.rs
@@ -102,6 +102,7 @@ pub struct CollateralManagement {
     pub chain_id: u32,
     pub address: Address,
     pub client_order_id: ClientOrderId,
+    pub symbol: Symbol,
     pub side: Side,
     pub collateral_amount: Amount,
     pub asset_requirements: HashMap<Symbol, Amount>,
@@ -1703,6 +1704,7 @@ mod test {
             .unwrap()
             .add_chain_source(
                 chain_id,
+                get_mock_index_name_1(),
                 collateral_designation_1
                     .read()
                     .unwrap()

--- a/src/solver/solvers/simple_solver.rs
+++ b/src/solver/solvers/simple_solver.rs
@@ -1407,6 +1407,7 @@ impl SolverStrategy for SimpleSolver {
             chain_id: order.chain_id,
             address: order.address,
             client_order_id: order.client_order_id.clone(),
+            symbol: order.symbol.clone(),
             side: order.side,
             collateral_amount,
             asset_requirements: HashMap::new(),


### PR DESCRIPTION
https://github.com/IndexMaker/index-maker/issues/163

Currently Colateral Router is configured to map chain_id => source designation we need to change that so it will map chain_id x symbol => source designation.

This is important change as each OTCIndex has its own CustodyID in OTCCustody. The dependency on chain_id stays, as on each chain (Base, Arbitrum) there will be separate instance of smart-contracts deployed.