### PR TITLE
Add solver state persistence across restarts

### DIFF
--- a/libs/symm-core/src/core/bits.rs
+++ b/libs/symm-core/src/core/bits.rs
@@ -67,7 +67,7 @@ string_id!(ClientOrderId);
 string_id!(ClientQuoteId);
 string_id!(PaymentId);
 
-#[derive(Hash, Eq, PartialEq, Clone, Copy, Serialize, Debug)]
+#[derive(Hash, Eq, PartialEq, Clone, Copy, Serialize, Deserialize, Debug)]
 pub enum Side {
     Buy,
     Sell,

--- a/libs/symm-core/src/core/telemetry.rs
+++ b/libs/symm-core/src/core/telemetry.rs
@@ -3,7 +3,7 @@ use opentelemetry::propagation::{Extractor, Injector, TextMapPropagator};
 use opentelemetry::trace::TraceContextExt;
 use opentelemetry::{Context, KeyValue};
 use opentelemetry_sdk::propagation::TraceContextPropagator;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::any::type_name;
 use std::collections::HashMap;
 use std::marker::PhantomData;
@@ -40,7 +40,7 @@ fn extract_baggage(tracing_data: &TracingData) -> Vec<(String, String)> {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct TracingData {
     properties: Option<HashMap<String, String>>,
 }

--- a/libs/symm-core/src/order_sender/position.rs
+++ b/libs/symm-core/src/order_sender/position.rs
@@ -15,6 +15,7 @@ use crate::{
 
 string_id!(LotId);
 
+#[derive(Serialize, Deserialize)]
 pub struct LotTransaction {
     /// ID of the closing order that was executed
     pub order_id: OrderId,
@@ -53,7 +54,7 @@ pub struct LotTransaction {
 /// short-selling.
 ///
 
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Lot {
     /// ID of the order that was executed, and caused to open this lot
     pub original_order_id: OrderId,
@@ -96,7 +97,7 @@ impl Lot {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Position {
     /// An asset we received
     pub symbol: Symbol,

--- a/src/solver/index_order.rs
+++ b/src/solver/index_order.rs
@@ -4,13 +4,14 @@ use chrono::{DateTime, Utc};
 use eyre::{eyre, OptionExt, Result};
 use itertools::Itertools;
 use safe_math::safe;
+use serde::{Deserialize, Serialize};
 
 use symm_core::core::{
     bits::{Address, Amount, ClientOrderId, Side, Symbol},
     decimal_ext::DecimalExt,
 };
 
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct IndexOrderUpdate {
     /// ID of the update assigned by the user (<- FIX)
     pub client_order_id: ClientOrderId,
@@ -41,7 +42,7 @@ pub struct IndexOrderUpdate {
 }
 
 /// An order to buy index
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct IndexOrder {
     /// Chain ID
     pub chain_id: u32,

--- a/src/solver/solver_order.rs
+++ b/src/solver/solver_order.rs
@@ -9,6 +9,7 @@ use itertools::Itertools;
 use parking_lot::RwLock;
 use safe_math::safe;
 
+
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use symm_core::{
@@ -20,7 +21,7 @@ use symm_core::{
     order_sender::position::LotId,
 };
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub enum SolverOrderStatus {
     Open,
     ManageCollateral,
@@ -165,6 +166,8 @@ impl SolverClientOrders {
             client_wait_period,
         }
     }
+
+
 
     pub fn get_client_order(
         &self,


### PR DESCRIPTION
This PR is for #82 issue.

notes: 

In https://github.com/IndexMaker/index-maker/blob/feat/82-add-solver-state-persistence-across-restarts/src/solver/solver.rs#L1540-L1543, I still put TODO because when I try to store client_orders, ready_orders, ready_mints, I need `Arc<RwLock<>>`, which will cause the item to mutably-shareable.

