### PR TITLE
Fix Binance reconnection and disconnection detection

### DIFF
--- a/libs/binance-order-sending/src/arbiter.rs
+++ b/libs/binance-order-sending/src/arbiter.rs
@@ -1,18 +1,33 @@
-use std::sync::Arc;
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::Arc,
+};
 
 use chrono::Utc;
 use eyre::Report;
 use itertools::Either;
 use parking_lot::RwLock as AtomicLock;
 use symm_core::{
-    core::{async_loop::AsyncLoop, bits::Symbol, functional::SingleObserver},
+    core::{
+        async_loop::AsyncLoop,
+        bits::Symbol,
+        functional::{OneShotPublishSingle, PublishSingle, SingleObserver},
+    },
     order_sender::order_connector::{OrderConnectorNotification, SessionId},
 };
-use tokio::{select, sync::mpsc::UnboundedReceiver, task::JoinError};
+use tokio::{
+    select,
+    sync::mpsc::{error::TryRecvError, UnboundedReceiver},
+    task::JoinError,
+};
 
 use crate::{
-    binance_order_sending::BinanceFeeCalculator, credentials::Credentials,
-    session_completion::SessionCompletionResult, sessions::Sessions, subaccounts::SubAccounts,
+    binance_order_sending::BinanceFeeCalculator,
+    command::{self, Command},
+    credentials::{self, Credentials},
+    session_completion::SessionCompletionResult,
+    sessions::Sessions,
+    subaccounts::SubAccounts,
 };
 
 /// Arbiter manages open sessions
@@ -47,6 +62,9 @@ impl Arbiter {
         sessions: Arc<AtomicLock<Sessions>>,
         observer: Arc<AtomicLock<SingleObserver<OrderConnectorNotification>>>,
     ) {
+        // TODO: Configure me!
+        let mut check_period = tokio::time::interval(std::time::Duration::from_secs(3));
+
         self.arbiter_loop.start(async move |cancel_token| {
             tracing::info!("Loop started");
             loop {
@@ -54,6 +72,35 @@ impl Arbiter {
                     _ = cancel_token.cancelled() => {
                         break
                     },
+                    _ = check_period.tick() => {
+                        let lost_sessions_ok = sessions.write().check_stopped();
+                        match lost_sessions_ok {
+                            Ok(lost_sessions) => {
+                                for mut session in lost_sessions {
+                                    let session_ok = session.stop().await;
+                                    match session_ok {
+                                        Ok((command_rx, completition)) => {
+                                            Self::process_session_completion(
+                                                command_rx,
+                                                completition,
+                                                true,
+                                                &sessions,
+                                                &symbols,
+                                                fee_calculator.clone(),
+                                                &observer,
+                                            ).await;
+                                        },
+                                        Err(err) => {
+                                            tracing::warn!("Failed to join stopped session: {:?}", err);   
+                                        }
+                                    }
+                                }
+                            }
+                            Err(err) => {
+                                tracing::warn!("Error while watching subscriptions {:?}", err);
+                            }
+                        }
+                    }
                     Some(credentials) = subaccount_rx.recv() => {
                         let account_name = credentials.get_account_name();
                         match sessions.write().add_session(
@@ -72,19 +119,14 @@ impl Arbiter {
                 }
             }
 
-            // Enhanced shutdown with disconnection handling
             let all_sessions = sessions.write().drain_all_sessions();
-            let completion_results = match Sessions::stop_all(all_sessions).await {
-                Ok(res) => res,
-                Err(err) => {
-                    tracing::warn!("Error stopping sessions {:?}", err);
-                    Vec::new()
-                }
-            };
+            let session_completitions = Sessions::stop_all(all_sessions).await;
 
-            for result in completion_results {
+            for (command_rx, completition) in session_completitions {
                 Self::process_session_completion(
-                    result,
+                    command_rx,
+                    completition,
+                    false,
                     &sessions,
                     &symbols,
                     fee_calculator.clone(),
@@ -98,19 +140,41 @@ impl Arbiter {
     }
 
     async fn process_session_completion(
+        mut command_rx: UnboundedReceiver<Command>,
         completion_result: SessionCompletionResult,
+        should_attempt_reconnection: bool,
         sessions: &Arc<AtomicLock<Sessions>>,
         symbols: &[Symbol],
         fee_calculator: BinanceFeeCalculator,
         observer: &Arc<AtomicLock<SingleObserver<OrderConnectorNotification>>>,
     ) {
-        match completion_result {
+        // We must drain all unprocessed commands and then either re-send them
+        // to new session or reply to them.
+        let mut commands = VecDeque::new();
+        loop {
+            match command_rx.try_recv() {
+                Ok(command) => {
+                    tracing::debug!("Drained command: {:?}", command);
+                    commands.push_back(command);
+                }
+                Err(TryRecvError::Empty) => {
+                    tracing::info!("No more commants: All commands drained");
+                    break;
+                }
+                Err(TryRecvError::Disconnected) => {
+                    tracing::warn!("Failed to drain commands: Channel disconnected");
+                    break;
+                }
+            }
+        }
+
+        let commands = match completion_result {
             SessionCompletionResult::Success(credentials) => {
                 tracing::info!(
                     "Session {} completed successfully",
-                    credentials.into_session_id()
+                    credentials.account_name()
                 );
-                // Session completed normally, no action needed
+                commands
             }
             SessionCompletionResult::Error {
                 error,
@@ -119,19 +183,55 @@ impl Arbiter {
             } => {
                 tracing::warn!("Session {} terminated with error: {}", session_id, error);
 
-                // Only attempt reconnection if error should trigger it and we have credentials
-                if error.should_reconnect() {
-                    if let Some(creds) = credentials {
+                match (
+                    credentials,
+                    should_attempt_reconnection && error.should_reconnect(),
+                ) {
+                    (Some(credentials), true) => {
+                        // When we try reconnection, we should attempt to
+                        // re-send all unprocessed commands to new session
                         Self::attempt_reconnection(
-                            creds,
+                            credentials,
+                            commands,
                             sessions,
                             symbols,
                             fee_calculator,
                             observer,
-                            &session_id,
                         )
-                        .await;
+                        .await
                     }
+                    _ => commands,
+                }
+            }
+        };
+
+        // We must reply to all unprocessed commands, otherwise client will be
+        // waiting indefinitely for reply
+        for command in commands {
+            match command {
+                Command::EnableTrading(_) => {
+                    tracing::warn!("Failed to enable trading: Session disconnected")
+                }
+                Command::NewOrder(single_order) => {
+                    tracing::warn!("Failed to send new order: Session disconnected");
+                    observer
+                        .read()
+                        .publish_single(OrderConnectorNotification::Rejected {
+                            order_id: single_order.order_id.clone(),
+                            symbol: single_order.symbol.clone(),
+                            side: single_order.side,
+                            price: single_order.price,
+                            quantity: single_order.quantity,
+                            reason: String::from("Sesssion disconnected"),
+                            timestamp: Utc::now(),
+                        });
+                }
+                Command::GetExchangeInfo(_) => {
+                    tracing::warn!("Failed to obtain exchange info: Session disconnected")
+                }
+                Command::GetBalances(one_shot_single_observer) => {
+                    tracing::warn!("Failed to obtain balances: Session disconnected");
+                    one_shot_single_observer.one_shot_publish_single(HashMap::new());
                 }
             }
         }
@@ -139,15 +239,17 @@ impl Arbiter {
 
     async fn attempt_reconnection(
         credentials: Credentials,
+        commands: VecDeque<Command>,
         sessions: &Arc<AtomicLock<Sessions>>,
         symbols: &[Symbol],
         fee_calculator: BinanceFeeCalculator,
         observer: &Arc<AtomicLock<SingleObserver<OrderConnectorNotification>>>,
-        original_session_id: &SessionId,
-    ) {
+    ) -> VecDeque<Command> {
+        let account_name = credentials.account_name().to_owned();
+
         tracing::info!(
             "Attempting to recreate session {} after error",
-            original_session_id
+            account_name
         );
 
         match sessions.write().add_session(
@@ -156,19 +258,26 @@ impl Arbiter {
             fee_calculator,
             observer.clone(),
         ) {
-            Ok(_) => {
+            Ok(session) => {
                 tracing::info!(
                     "Successfully recreated session {} after error",
-                    original_session_id
+                    account_name
                 );
-                // Note: Session will publish its own SessionLogon event, no need to publish here
+
+                let mut failed_commands = VecDeque::new();
+
+                for command in commands {
+                    if let Err(command) = session.send_command(command) {
+                        tracing::warn!("Failed to resend command to session {}", account_name);
+                        failed_commands.push_back(command);
+                    }
+                }
+
+                failed_commands
             }
             Err(err) => {
-                tracing::error!(
-                    "Failed to recreate session {}: {:?}",
-                    original_session_id,
-                    err
-                );
+                tracing::error!("Failed to recreate session {}: {:?}", account_name, err);
+                commands
             }
         }
     }

--- a/libs/binance-order-sending/src/trading_session.rs
+++ b/libs/binance-order-sending/src/trading_session.rs
@@ -425,7 +425,7 @@ impl TradingSession {
     }
 
     /// Attempt to ping the WebSocket connection
-    pub async fn ping_connection(&self) -> Result<()> {
+    pub async fn ping_connection(&self) -> Result<(), SessionError> {
         tracing::trace!(
             "Pinging WebSocket connection for session {}",
             self.session_id
@@ -445,7 +445,10 @@ impl TradingSession {
                     self.session_id,
                     err
                 );
-                Err(eyre!("WebSocket ping failed: {:?}", err))
+                Err(SessionError::from_eyre(&eyre::eyre!(
+                    "Failed to ping session: {:?}",
+                    err
+                )))
             }
         }
     }

--- a/libs/symm-core/src/order_sender/inventory_manager.rs
+++ b/libs/symm-core/src/order_sender/inventory_manager.rs
@@ -23,7 +23,7 @@ use crate::{
         persistence::{Persist, Persistence},
         telemetry::{TracingData, WithBaggage},
     },
-    order_sender::position::{self, LotAssignment},
+    order_sender::{order_tracker::CancelStatus, position::{self, LotAssignment}},
 };
 use derive_with_baggage::WithBaggage;
 use opentelemetry::propagation::Injector;
@@ -120,7 +120,7 @@ pub enum InventoryEvent {
         quantity_cancelled: Amount,
         original_quantity: Amount,
         quantity_remaining: Amount,
-        is_cancelled: bool,
+        cancel_status: CancelStatus,
         cancel_timestamp: DateTime<Utc>,
     },
 }
@@ -344,7 +344,7 @@ impl InventoryManager {
                         quantity_cancelled: Amount::ZERO,
                         original_quantity,
                         quantity_remaining,
-                        is_cancelled: true,
+                        cancel_status: CancelStatus::FullyCancelled,
                         cancel_timestamp: fill_timestamp,
                     });
                 }
@@ -359,7 +359,7 @@ impl InventoryManager {
                 quantity_cancelled,
                 original_quantity,
                 quantity_remaining,
-                is_cancelled,
+                cancel_status,
                 cancel_timestamp,
             } => {
                 self.observer.publish_single(InventoryEvent::Cancel {
@@ -370,7 +370,7 @@ impl InventoryManager {
                     quantity_cancelled,
                     original_quantity,
                     quantity_remaining,
-                    is_cancelled,
+                    cancel_status,
                     cancel_timestamp,
                 });
                 Ok(())

--- a/src/app/solver.rs
+++ b/src/app/solver.rs
@@ -858,6 +858,15 @@ impl SolverConfig {
         }
     }
 
+    pub async fn check_solver_stopped(&mut self) -> Result<()> {
+        if let Some((_, solver_stopped_rx)) = &mut self.stopping_solver {
+            solver_stopped_rx.await?;
+            Ok(())
+        } else {
+            Err(eyre!("Cannot stop solver: Not started"))
+        }
+    }
+
     pub async fn run(&mut self) -> Result<()> {
         self.run_orders_backend().await?;
         self.run_quotes_backend().await?;
@@ -889,7 +898,7 @@ impl SolverConfig {
         // 3. Stop dispatching server events
         self.stop_orders_backend().await?;
         self.stop_quotes_backend().await?;
-        
+
         // 4. Stop receiving market data
         self.stop_market_data().await?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -717,6 +717,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut sigquit = signal(SignalKind::quit())?;
 
     tokio::select! {
+        _ = solver_config.check_solver_stopped() => {
+            panic!("Solver terminated unexpectedly");
+        }
         _ = sigint.recv() => {
             tracing::info!("SIGINT received")
         }

--- a/src/solver/solver.rs
+++ b/src/solver/solver.rs
@@ -867,9 +867,15 @@ impl Solver {
                         .collect_vec()),
                     "Batch Complete");
 
-                // Batch completion is now tracked via BatchManager status
+                let is_last_batch = continued_orders.is_empty();
 
                 self.ready_orders.lock().extend(continued_orders);
+
+                if is_last_batch {
+                    if let Err(err) = self.inventory_manager.write().update_snapshot() {
+                        tracing::warn!("Failed to update inventory snapshot: {:?}", err);
+                    }
+                }
                 Ok(())
             }
             BatchEvent::BatchMintable { mintable_orders } => {


### PR DESCRIPTION
# Work
- [x] Fix: Unwanted session disconnection when order is rejected
- [x] Check session still alive using periodic ping
- [x] Check lost sessions periodically
- [x] Resend unprocessed commands to re-connected sessions
- [x] Cancel unprocessed commands from disconnected sessions
- [x] Detect unrecoverable solver state and terminate with error and panic!

# About
1.) There was a bug, when new order sending error occurred, then session loop exited. This was unintended as connection waasn't terminated. Removed that part of code and replaced with periodic ping.

2.) Added periodic check for lost sessions in Arbiter. This was completely missing. When session was disconnected and loop exited nothing would happen, because Arbiter loop would just continue waiting for new logon commands. What was required was to periodically check for lost sesions. To do that we can query state of AsyncLoop.

3.) When session loop exists there might still be commands in the channel, and these commands require to be processed. Added so that if we re-connect session, the commands are re-sent to that new session, and if we don't reconnect commands are replied with rejection. This is critical, as client (Solver & QueryService) must receive reply to every command, whether it is a fill, cancel, or rejection.

4.) When orders cannot be sent to Binance, then it is unrecoverable state (atm) and we must have a way to terminate application if it reaches that state. We cannot continue sending orders that are beign rejected, we have to stop and manually investigate issue in that case.  Future TODO: analyse how can this be improved (not now!)

